### PR TITLE
Merge staging: result card export fixes

### DIFF
--- a/apps/ledger/app/controllers/match_exports_controller.rb
+++ b/apps/ledger/app/controllers/match_exports_controller.rb
@@ -6,7 +6,8 @@ class MatchExportsController < ApplicationController
     set_export
     send_export_file(disposition: :attachment)
   rescue StandardError => error
-    redirect_to match_path(id: @match), alert: t("flash.matches.export_failed", message: error.message)
+    Rails.logger.error("Match export failed for #{@match.id}: #{error.class}: #{error.message}")
+    redirect_to match_path(id: @match), alert: export_error_message(error)
   end
 
   private
@@ -47,5 +48,14 @@ class MatchExportsController < ApplicationController
     home = @match.home_team.display_name.to_s.parameterize.presence || "home"
     away = @match.away_team.display_name.to_s.parameterize.presence || "away"
     "#{home}-vs-#{away}.png"
+  end
+
+  def export_error_message(error)
+    case error
+    when Ferrum::TimeoutError
+      t("flash.matches.export_timeout")
+    else
+      t("flash.matches.export_failed")
+    end
   end
 end

--- a/apps/ledger/app/controllers/standings_controller.rb
+++ b/apps/ledger/app/controllers/standings_controller.rb
@@ -17,8 +17,9 @@ class StandingsController < ApplicationController
     filename = "standings-#{league_label}.png"
     send_file output_path, filename: filename, type: "image/png", disposition: "attachment"
   rescue => e
+    Rails.logger.error("Standings export failed for phase #{@phase.id}: #{e.class}: #{e.message}")
     redirect_to league_phase_standings_path(league_id: @league, phase_id: @phase),
-      alert: t("flash.standings.export_failed", message: e.message)
+      alert: export_error_message(e)
   end
 
   private
@@ -28,5 +29,14 @@ class StandingsController < ApplicationController
       .where(id: params[:phase_id], leagues: { organizer_account_id: current_organizer_account.id })
       .first!
     @league = @phase.league
+  end
+
+  def export_error_message(error)
+    case error
+    when Ferrum::TimeoutError
+      t("flash.standings.export_timeout")
+    else
+      t("flash.standings.export_failed")
+    end
   end
 end

--- a/apps/ledger/app/models/board_result.rb
+++ b/apps/ledger/app/models/board_result.rb
@@ -10,7 +10,7 @@ class BoardResult < ApplicationRecord
   belongs_to :away_participant, class_name: "Participant", optional: true
 
   enum :result_status, RESULT_STATUSES, validate: true
-  enum :winner_side, WINNER_SIDES, validate: true, allow_nil: true
+  enum :winner_side, WINNER_SIDES, validate: { allow_nil: true }
 
   validates :board_number, presence: true, uniqueness: { scope: :round_id }
   validates :home_game_wins, :away_game_wins, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 2 }, allow_nil: true

--- a/apps/ledger/app/services/match_exports/result_card_renderer.rb
+++ b/apps/ledger/app/services/match_exports/result_card_renderer.rb
@@ -8,6 +8,7 @@ module MatchExports
     RENDERER_KEY = "match_result_card_v2".freeze
     WIDTH = 1024
     HEIGHT = 1449
+    BROWSER_TIMEOUT = 30
     OUTPUT_DIR = Rails.root.join("public", "generated", "match_exports")
 
     def initialize(match)
@@ -25,6 +26,7 @@ module MatchExports
         headless: "new",
         browser_path: ENV["CHROMIUM_PATH"],
         window_size: [WIDTH, HEIGHT],
+        timeout: BROWSER_TIMEOUT,
         args: ["--no-sandbox", "--disable-gpu"]
       )
       begin

--- a/apps/ledger/app/services/match_exports/result_card_renderer.rb
+++ b/apps/ledger/app/services/match_exports/result_card_renderer.rb
@@ -248,20 +248,26 @@ module MatchExports
               background: #0f172a;
               margin: 24px 20px 0;
               height: 70px;
-              display: flex;
+              display: grid;
+              grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
               align-items: center;
-              justify-content: center;
-              gap: 40px;
+              column-gap: 32px;
+              padding: 0 28px;
             }
             .footer-team {
               color: #fff;
               font-size: 34px;
               font-weight: 800;
-              max-width: 280px;
               overflow: hidden;
               text-overflow: ellipsis;
               white-space: nowrap;
-              text-align: center;
+              line-height: 1;
+            }
+            .footer-team.home {
+              text-align: right;
+            }
+            .footer-team.away {
+              text-align: left;
             }
             .footer-score {
               color: #fff;
@@ -269,6 +275,7 @@ module MatchExports
               font-weight: 900;
               min-width: 120px;
               text-align: center;
+              line-height: 1;
             }
           </style>
         </head>
@@ -397,9 +404,9 @@ module MatchExports
       away_score = result&.away_round_wins.to_i
       <<~HTML
         <div class="footer">
-          <div class="footer-team">#{h match.home_team.display_name}</div>
+          <div class="footer-team home">#{h match.home_team.display_name}</div>
           <div class="footer-score">#{home_score} - #{away_score}</div>
-          <div class="footer-team">#{h match.away_team.display_name}</div>
+          <div class="footer-team away">#{h match.away_team.display_name}</div>
         </div>
       HTML
     end

--- a/apps/ledger/app/services/match_exports/result_card_renderer.rb
+++ b/apps/ledger/app/services/match_exports/result_card_renderer.rb
@@ -195,6 +195,7 @@ module MatchExports
               width: 100%;
               border-collapse: collapse;
               table-layout: fixed;
+              font-variant-numeric: tabular-nums;
             }
             .board-table th {
               background: #111827;
@@ -202,7 +203,10 @@ module MatchExports
               font-size: 19px;
               font-weight: 800;
               padding: 6px 4px;
+              height: 42px;
+              line-height: 1.05;
               text-align: center;
+              vertical-align: middle;
             }
             .board-table td {
               background: #ffe082;
@@ -210,7 +214,10 @@ module MatchExports
               font-size: 20px;
               font-weight: 700;
               padding: 10px 4px;
+              height: 60px;
+              line-height: 1.15;
               text-align: center;
+              vertical-align: middle;
               border: 1px solid #111827;
               overflow: hidden;
               text-overflow: ellipsis;
@@ -219,6 +226,7 @@ module MatchExports
             .board-table .score-cell {
               font-size: 26px;
               font-weight: 800;
+              line-height: 1;
             }
             col.c-player { width: 16%; }
             col.c-deck { width: 26%; }
@@ -231,6 +239,7 @@ module MatchExports
               padding: 4px 0;
               font-size: 28px;
               font-weight: 900;
+              line-height: 1;
             }
             .win { color: #ef4444; }
             .lose { color: #2563eb; }

--- a/apps/ledger/app/services/match_exports/result_card_renderer.rb
+++ b/apps/ledger/app/services/match_exports/result_card_renderer.rb
@@ -7,7 +7,7 @@ module MatchExports
     EXPORT_TYPE = "match_result_card".freeze
     RENDERER_KEY = "match_result_card_v2".freeze
     WIDTH = 1024
-    HEIGHT = 1449
+    MIN_HEIGHT = 1449
     BROWSER_TIMEOUT = 30
     OUTPUT_DIR = Rails.root.join("public", "generated", "match_exports")
 
@@ -25,15 +25,16 @@ module MatchExports
       browser = Ferrum::Browser.new(
         headless: "new",
         browser_path: ENV["CHROMIUM_PATH"],
-        window_size: [WIDTH, HEIGHT],
+        window_size: [WIDTH, MIN_HEIGHT],
         timeout: BROWSER_TIMEOUT,
         args: ["--no-sandbox", "--disable-gpu"]
       )
       begin
         page = browser.create_page
         page.main_frame.set_content(html_document)
-        page.set_viewport(width: WIDTH, height: HEIGHT)
-        page.screenshot(path: output_path.to_s, format: "png")
+        height = page.evaluate("Math.max(document.body.scrollHeight, document.documentElement.scrollHeight)")
+        page.set_viewport(width: WIDTH, height: [height.to_i, MIN_HEIGHT].max)
+        page.screenshot(path: output_path.to_s, format: "png", full: true)
       ensure
         browser.quit
       end
@@ -91,9 +92,8 @@ module MatchExports
             * { margin: 0; padding: 0; box-sizing: border-box; }
             body {
               width: #{WIDTH}px;
-              height: #{HEIGHT}px;
+              min-height: #{MIN_HEIGHT}px;
               font-family: 'Noto Sans', 'Noto Sans CJK JP', sans-serif;
-              overflow: hidden;
               #{canvas_background_css}
             }
 

--- a/apps/ledger/app/services/standings_exports/table_renderer.rb
+++ b/apps/ledger/app/services/standings_exports/table_renderer.rb
@@ -3,6 +3,7 @@ require "erb"
 
 module StandingsExports
   class TableRenderer
+    BROWSER_TIMEOUT = 30
     OUTPUT_DIR = Rails.root.join("public", "generated", "standings_exports")
 
     def initialize(phase, standings_by_block, blocks)
@@ -20,6 +21,7 @@ module StandingsExports
         headless: "new",
         browser_path: ENV["CHROMIUM_PATH"],
         window_size: [1024, 800],
+        timeout: BROWSER_TIMEOUT,
         args: ["--no-sandbox", "--disable-gpu"]
       )
       begin

--- a/apps/ledger/config/locales/en.yml
+++ b/apps/ledger/config/locales/en.yml
@@ -142,9 +142,11 @@ en:
       bracket_progress_locked: The next bracket card already has a result, so advancement cannot be updated.
       lineup_updated: Order updated.
       results_updated: Match result updated.
-      export_failed: "Failed to generate match image: %{message}"
+      export_failed: Failed to generate the match image. Please try again in a moment.
+      export_timeout: Match image generation timed out. Please wait a moment and try again.
     standings:
-      export_failed: "Standings export failed: %{message}"
+      export_failed: Failed to generate the standings image. Please try again in a moment.
+      export_timeout: Standings image generation timed out. Please wait a moment and try again.
   shared:
     errors:
       title: Please review the highlighted fields.
@@ -677,8 +679,17 @@ en:
         bracket_slot: Bracket slot
         room_id: Room ID
         spectator_room_id: Spectator ID
+      board_result:
+        round: Round
+        board_number: Board number
+        home_game_wins: Home game wins
+        away_game_wins: Away game wins
+        winner_side: Winner side
     errors:
       messages:
+        blank: can't be blank.
+        inclusion: is not included in the list.
+        required: must exist.
         record_invalid: "Validation failed: %{errors}"
         taken: has already been taken.
       models:
@@ -686,7 +697,6 @@ en:
           attributes:
             base:
               invalid_game_score_pattern: Game score must be one of 2-0, 2-1, 1-2, or 0-2.
-        notes: Notes
   helpers:
     submit:
       create: "Create %{model}"

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -142,9 +142,11 @@ ja:
       bracket_progress_locked: 次のカードに結果が入っているため、勝ち上がり先を更新できません。
       lineup_updated: オーダーを更新しました。
       results_updated: 対戦結果を更新しました。
-      export_failed: "対戦画像の出力に失敗しました: %{message}"
+      export_failed: 対戦画像の出力に失敗しました。時間をおいて再度お試しください。
+      export_timeout: 対戦画像の出力がタイムアウトしました。少し待ってから再度お試しください。
     standings:
-      export_failed: "順位表画像の出力に失敗しました: %{message}"
+      export_failed: 順位表画像の出力に失敗しました。時間をおいて再度お試しください。
+      export_timeout: 順位表画像の出力がタイムアウトしました。少し待ってから再度お試しください。
   shared:
     errors:
       title: 入力内容を確認してください。
@@ -677,9 +679,17 @@ ja:
         bracket_slot: ブラケット位置
         room_id: ルームID
         spectator_room_id: 観戦ID
+      board_result:
+        round: ラウンド
+        board_number: 卓番号
+        home_game_wins: ホームゲーム勝数
+        away_game_wins: アウェイゲーム勝数
+        winner_side: 勝者サイド
     errors:
       messages:
         blank: を入力してください。
+        inclusion: は一覧にありません。
+        required: を入力してください。
         record_invalid: "保存に失敗しました: %{errors}"
         taken: はすでに使われています。
       models:
@@ -687,7 +697,6 @@ ja:
           attributes:
             base:
               invalid_game_score_pattern: ゲーム数は 2-0, 2-1, 1-2, 0-2 のいずれかで入力してください。
-        notes: メモ
   helpers:
     submit:
       create: "%{model}を作成"

--- a/apps/ledger/test/integration/regular_season_operations_flow_test.rb
+++ b/apps/ledger/test/integration/regular_season_operations_flow_test.rb
@@ -129,6 +129,57 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
     assert_includes response.headers["Content-Disposition"], "attachment"
   end
 
+  test "match export timeout shows a localized alert instead of raw exception text" do
+    login_as!(@organizer_account, password: @password)
+
+    league = @organizer_account.leagues.create!(
+      name: "Export Timeout League",
+      status: "draft",
+      roster_min_members: 4,
+      roster_max_members: 8,
+      lineup_size: 3,
+      substitute_size: 1
+    )
+    phase = league.phases.create!(name: "予選 1", stage_asset: regular_stage_asset, position: 1)
+    block = phase.blocks.create!(league:, name: "Block A", position: 1)
+    week = phase.weeks.create!(league:, number: 1, position: 1)
+    team_a = create_team_record_with_members!(league:, name: "Export Team A")
+    team_b = create_team_record_with_members!(league:, name: "Export Team B")
+    match = week.matches.create!(
+      league: league,
+      phase: phase,
+      block: block,
+      home_team: team_a,
+      away_team: team_b,
+      scheduled_on: Date.new(2026, 4, 9),
+      scheduled_time: Time.zone.parse("20:00"),
+      status: "scheduled"
+    )
+
+    timeout_renderer = Object.new
+    def timeout_renderer.render!
+      raise Ferrum::TimeoutError, "Timed out waiting for response."
+    end
+
+    renderer_singleton = MatchExports::ResultCardRenderer.singleton_class
+    original_new = MatchExports::ResultCardRenderer.method(:new)
+    renderer_singleton.send(:define_method, :new) do |*|
+      timeout_renderer
+    end
+
+    begin
+      get download_match_result_card_export_path(locale: :ja, match_id: match)
+    ensure
+      renderer_singleton.send(:define_method, :new, original_new)
+    end
+
+    assert_redirected_to match_path(locale: :ja, id: match)
+    follow_redirect!
+    assert_response :success
+    assert_includes response.body, "対戦画像の出力がタイムアウトしました。少し待ってから再度お試しください。"
+    refute_includes response.body, "Timed out waiting for response"
+  end
+
   test "organizer can create a tournament phase before setting participant count" do
     login_as!(@organizer_account, password: @password)
 

--- a/apps/ledger/test/models/board_result_test.rb
+++ b/apps/ledger/test/models/board_result_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+class BoardResultTest < ActiveSupport::TestCase
+  test "winner_side allows nil for partial board results" do
+    round = create_round_for_board_result_test!
+
+    board_result = round.board_results.build(
+      board_number: 1,
+      result_status: "partial",
+      winner_side: nil
+    )
+
+    assert board_result.valid?
+  end
+
+  test "winner_side inclusion error is localized in Japanese" do
+    round = create_round_for_board_result_test!
+
+    board_result = round.board_results.build(
+      board_number: 1,
+      result_status: "partial"
+    )
+    board_result[:winner_side] = "invalid"
+
+    I18n.with_locale(:ja) do
+      assert_not board_result.valid?
+      assert_includes board_result.errors.full_messages, "勝者サイド は一覧にありません。"
+    end
+  end
+
+  private
+
+  def create_round_for_board_result_test!
+    organizer_account = OrganizerAccount.create!(
+      email: "board-result-test@example.com",
+      login_id: "board-result-test",
+      password: "password",
+      display_name: "Board Result Test"
+    )
+    league = organizer_account.leagues.create!(
+      name: "Board Result Test League",
+      started_at: Date.new(2026, 4, 9)
+    )
+    phase = league.phases.create!(
+      name: "予選 1",
+      position: 1,
+      rule_module_key: "wmgp",
+      bracket_enabled: false
+    )
+    week = phase.weeks.create!(
+      league: league,
+      number: 1,
+      position: 1
+    )
+    home_team = league.teams.create!(display_name: "Home Team", status: "active")
+    away_team = league.teams.create!(display_name: "Away Team", status: "active")
+    match = week.matches.create!(
+      league: league,
+      phase: phase,
+      home_team: home_team,
+      away_team: away_team,
+      status: "scheduled"
+    )
+
+    match.rounds.create!(
+      number: 1,
+      home_team: home_team,
+      away_team: away_team,
+      result_status: "partial"
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- fix result card export footer clipping and footer alignment
- improve result card row alignment for generated images
- widen result entry layout and fix score select clipping
- add i18n/error handling updates around match export and board result validation

## Verification
- bin/rails test test/integration/regular_season_operations_flow_test.rb
- bin/rails test test/models/board_result_test.rb
- staging deploys succeeded, including latest run 24200734293