### PR TITLE
Promote staging changes to main

### DIFF
--- a/apps/ledger/app/assets/stylesheets/application.css
+++ b/apps/ledger/app/assets/stylesheets/application.css
@@ -187,6 +187,10 @@ ol {
   flex-wrap: wrap;
 }
 
+.page-actions form {
+  margin: 0;
+}
+
 .nav-link {
   padding: 0.55rem 0.9rem;
   border-radius: 0.65rem;
@@ -973,6 +977,10 @@ h2 {
   padding-top: 0.2rem;
 }
 
+.result-entry-cell {
+  min-width: 0;
+}
+
 .result-entry-row__board {
   display: inline-flex;
   align-items: center;
@@ -1110,13 +1118,56 @@ h2 {
     grid-template-columns: 1fr;
   }
 
+  .page-actions {
+    width: 100%;
+    align-items: stretch;
+  }
+
+  .page-actions > *,
+  .page-actions form {
+    flex: 1 1 100%;
+  }
+
+  .page-actions .button,
+  .page-actions form .button {
+    width: 100%;
+  }
+
   .result-entry-table__header {
     display: none;
   }
 
   .result-entry-row {
     grid-template-columns: 1fr;
+    gap: 0.85rem;
+    padding: 1rem;
+    border: 1px solid var(--line);
+    border-radius: 0.9rem;
+    background: #fff;
   }
+
+  .result-entry-row:first-of-type {
+    padding-top: 1rem;
+  }
+
+  .result-entry-cell {
+    display: grid;
+    gap: 0.35rem;
+  }
+
+  .result-entry-cell::before {
+    content: attr(data-label);
+    color: var(--muted);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .result-entry-cell--board::before {
+    margin-bottom: 0.1rem;
+  }
+
 
   .login-screen {
     padding-top: 2.5rem;

--- a/apps/ledger/app/assets/stylesheets/application.css
+++ b/apps/ledger/app/assets/stylesheets/application.css
@@ -1073,6 +1073,7 @@ h2 {
   }
 
   .topbar {
+    position: static;
     align-items: flex-start;
   }
 

--- a/apps/ledger/app/controllers/match_exports_controller.rb
+++ b/apps/ledger/app/controllers/match_exports_controller.rb
@@ -2,9 +2,15 @@ class MatchExportsController < ApplicationController
   before_action :set_match
 
   def download
-    MatchExports::ResultCardRenderer.new(@match).render!
-    set_export
-    send_export_file(disposition: :attachment)
+    export_manager = MatchExports::ResultCardExportManager.new(@match)
+    @export = export_manager.downloadable_export
+
+    if @export.present?
+      return send_export_file(disposition: :attachment)
+    end
+
+    export_manager.enqueue_refresh!
+    redirect_to match_path(id: @match), notice: export_pending_message(export_manager.state)
   rescue StandardError => error
     Rails.logger.error("Match export failed for #{@match.id}: #{error.class}: #{error.message}")
     redirect_to match_path(id: @match), alert: export_error_message(error)
@@ -26,10 +32,6 @@ class MatchExportsController < ApplicationController
         rounds: [:winner_team, { board_results: %i[home_participant away_participant] }]
       )
       .first!
-  end
-
-  def set_export
-    @export = @match.exports.find_by!(export_type: MatchExports::ResultCardRenderer::EXPORT_TYPE)
   end
 
   def send_export_file(disposition:)
@@ -56,6 +58,15 @@ class MatchExportsController < ApplicationController
       t("flash.matches.export_timeout")
     else
       t("flash.matches.export_failed")
+    end
+  end
+
+  def export_pending_message(state)
+    case state.to_sym
+    when :stale
+      t("flash.matches.export_refresh_started")
+    else
+      t("flash.matches.export_generation_started")
     end
   end
 end

--- a/apps/ledger/app/controllers/match_result_entries_controller.rb
+++ b/apps/ledger/app/controllers/match_result_entries_controller.rb
@@ -10,7 +10,8 @@ class MatchResultEntriesController < ApplicationController
     MatchResults::Recorder.new(@match, result_entry_params).save!
     @match.update_column(:judge_name, current_organizer_member.display_name)
     Brackets::ProgressionSync.new(@match).sync!
-    redirect_to edit_match_result_entry_path(match_id: @match), notice: t("flash.matches.results_updated")
+    MatchExports::ResultCardExportManager.new(@match).enqueue_refresh!
+    redirect_to edit_match_result_entry_path(match_id: @match), notice: t("flash.matches.results_updated_with_export")
   rescue Brackets::ProgressionSync::LockedError => error
     flash.now[:alert] = error.message
     set_result_form_state

--- a/apps/ledger/app/controllers/matches_controller.rb
+++ b/apps/ledger/app/controllers/matches_controller.rb
@@ -8,6 +8,7 @@ class MatchesController < ApplicationController
   def show
     @match_result = @match.match_result
     @rounds = @match.rounds.includes(:board_results).order(:number)
+    @result_card_export_state = MatchExports::ResultCardExportManager.new(@match).state
   end
 
   def new

--- a/apps/ledger/app/helpers/application_helper.rb
+++ b/apps/ledger/app/helpers/application_helper.rb
@@ -109,6 +109,25 @@ module ApplicationHelper
     match.week.display_name
   end
 
+  def result_card_export_status_label(state)
+    t("matches.result_card_status.#{state}")
+  end
+
+  def result_card_export_status_tone(state)
+    case state.to_sym
+    when :generated
+      "success"
+    when :pending, :stale
+      "warning"
+    else
+      "neutral"
+    end
+  end
+
+  def result_card_export_hint(state)
+    t("matches.result_card_hint.#{state}")
+  end
+
   def locale_switcher_path(locale)
     route_params = request.path_parameters.symbolize_keys.except(:format)
     route_params = { controller: "sessions", action: "new" } if route_params[:controller].blank? || route_params[:action].blank?

--- a/apps/ledger/app/jobs/match_exports/generate_result_card_job.rb
+++ b/apps/ledger/app/jobs/match_exports/generate_result_card_job.rb
@@ -1,0 +1,25 @@
+module MatchExports
+  class GenerateResultCardJob < ApplicationJob
+    queue_as :default
+
+    discard_on ActiveRecord::RecordNotFound
+
+    def perform(match_id)
+      match = Match.includes(
+        :league,
+        :phase,
+        :week,
+        :match_result,
+        :home_team,
+        :away_team,
+        { exports: [] },
+        { rounds: [:winner_team, { board_results: %i[home_participant away_participant] }] }
+      ).find(match_id)
+
+      ResultCardRenderer.new(match).render!
+    rescue StandardError => error
+      Rails.logger.error("Async match export failed for #{match_id}: #{error.class}: #{error.message}")
+      raise
+    end
+  end
+end

--- a/apps/ledger/app/models/board_result.rb
+++ b/apps/ledger/app/models/board_result.rb
@@ -23,7 +23,7 @@ class BoardResult < ApplicationRecord
   end
 
   def confirmed_score?
-    valid_confirmed_score?(home_game_wins, away_game_wins)
+    self.class.valid_confirmed_score?(home_game_wins, away_game_wins)
   end
 
   def inferred_winner_side
@@ -32,6 +32,7 @@ class BoardResult < ApplicationRecord
 
   def self.infer_winner_side(home_game_wins, away_game_wins)
     return nil unless valid_confirmed_score?(home_game_wins, away_game_wins)
+    return nil if home_game_wins == away_game_wins
 
     home_game_wins > away_game_wins ? "home" : "away"
   end
@@ -39,7 +40,7 @@ class BoardResult < ApplicationRecord
   def self.valid_confirmed_score?(home_game_wins, away_game_wins)
     return false if home_game_wins.nil? || away_game_wins.nil?
 
-    [[2, 0], [2, 1], [1, 2], [0, 2]].include?([home_game_wins, away_game_wins])
+    [[2, 0], [2, 1], [1, 1], [1, 2], [0, 2]].include?([home_game_wins, away_game_wins])
   end
 
   private

--- a/apps/ledger/app/services/match_exports/result_card_export_manager.rb
+++ b/apps/ledger/app/services/match_exports/result_card_export_manager.rb
@@ -1,0 +1,76 @@
+module MatchExports
+  class ResultCardExportManager
+    def initialize(match)
+      @match = match
+      @renderer = ResultCardRenderer.new(match)
+    end
+
+    def state
+      return :generated if downloadable_export.present?
+      return :pending if export&.pending?
+      return :stale if export&.stale? || export&.generated?
+
+      :missing
+    end
+
+    def downloadable_export
+      return unless renderer.fresh_export_available?
+
+      export
+    end
+
+    def enqueue_refresh!
+      export_record = match.exports.find_or_initialize_by(export_type: ResultCardRenderer::EXPORT_TYPE)
+      return export_record if export_already_queued?(export_record)
+
+      file_available = export_file_available?(export_record)
+
+      export_record.assign_attributes(
+        league: match.league,
+        renderer_key: ResultCardRenderer::RENDERER_KEY,
+        status: file_available ? "stale" : "pending"
+      )
+
+      unless file_available
+        export_record.file_path = nil
+        export_record.generated_at = nil
+      end
+
+      export_record.save!
+      GenerateResultCardJob.perform_later(match.id)
+      export_record
+    end
+
+    private
+
+    attr_reader :match, :renderer
+
+    def export
+      match.exports.find_by(export_type: ResultCardRenderer::EXPORT_TYPE)
+    end
+
+    def export_already_queued?(export_record)
+      return false unless export_record.persisted?
+      return false unless export_record.pending? || export_record.stale?
+
+      latest_change = latest_change_at
+      return true if latest_change.blank?
+
+      export_record.updated_at.present? && export_record.updated_at >= latest_change
+    end
+
+    def latest_change_at
+      [
+        match.match_result&.updated_at,
+        match.rounds.maximum(:updated_at)
+      ].compact.max
+    end
+
+    def export_file_available?(export_record)
+      file_path = export_record.file_path.presence
+      return false unless file_path
+
+      Rails.root.join("public", file_path.delete_prefix("/")).exist?
+    end
+  end
+end

--- a/apps/ledger/app/services/match_exports/result_card_renderer.rb
+++ b/apps/ledger/app/services/match_exports/result_card_renderer.rb
@@ -51,6 +51,10 @@ module MatchExports
       export
     end
 
+    def fresh_export_available?
+      fresh?
+    end
+
     private
 
     attr_reader :match

--- a/apps/ledger/app/services/match_results/recorder.rb
+++ b/apps/ledger/app/services/match_results/recorder.rb
@@ -93,6 +93,7 @@ module MatchResults
 
     def persist_match_result!(round_summaries)
       confirmed_rounds = round_summaries.select { |summary| summary[:confirmed] && summary[:winner_team_id].present? }
+      confirmed_round_count = round_summaries.count { |summary| summary[:confirmed] }
       home_round_wins = confirmed_rounds.count { |summary| summary[:winner_team_id] == match.home_team_id }
       away_round_wins = confirmed_rounds.count { |summary| summary[:winner_team_id] == match.away_team_id }
       any_input = round_summaries.any? { |summary| summary[:confirmed] || summary[:winner_team_id].present? } || match.rounds.exists?
@@ -112,7 +113,7 @@ module MatchResults
         elsif away_round_wins > home_round_wins
           match.away_team
         end
-      result.result_status = match_confirmed?(home_round_wins, away_round_wins) ? "confirmed" : "partial"
+      result.result_status = match_confirmed?(home_round_wins, away_round_wins, confirmed_round_count) ? "confirmed" : "partial"
       result.decision_type = "normal"
       result.confirmed_at = result.result_status == "confirmed" ? Time.current : nil
       result.save!
@@ -142,8 +143,11 @@ module MatchResults
       nil
     end
 
-    def match_confirmed?(home_round_wins, away_round_wins)
-      home_round_wins >= 2 || away_round_wins >= 2
+    def match_confirmed?(home_round_wins, away_round_wins, confirmed_round_count)
+      return true if home_round_wins >= 2 || away_round_wins >= 2
+      return false if match.bracket_match?
+
+      confirmed_round_count == ROUND_COUNT
     end
   end
 end

--- a/apps/ledger/app/views/leagues/_form.html.erb
+++ b/apps/ledger/app/views/leagues/_form.html.erb
@@ -1,6 +1,7 @@
 <%= render "shared/errors", record: league %>
+<% form_url = league.persisted? ? league_path(locale: I18n.locale, id: league) : leagues_path(locale: I18n.locale) %>
 
-<%= form_with model: league, class: "stack" do |form| %>
+<%= form_with model: league, url: form_url, class: "stack" do |form| %>
   <div class="field-grid">
     <div class="field">
       <%= form.label :name, t("leagues.form.name") %>

--- a/apps/ledger/app/views/match_result_entries/edit.html.erb
+++ b/apps/ledger/app/views/match_result_entries/edit.html.erb
@@ -58,38 +58,50 @@
 
           <% entry[:boards].each do |board| %>
             <div class="result-entry-row">
-              <div class="result-entry-row__board">#<%= board.board_number %></div>
-
-              <div class="field field--compact">
-                <label class="sr-only"><%= t("matches.result_entry.board_member", number: board.board_number, team: match_side_name(@match, "home")) %></label>
-                <%= select_tag "result_entry[rounds][#{round.number}][boards][#{board.board_number}][home_participant_id]", options_from_collection_for_select(@home_participant_options, :id, :display_name, board.home_participant_id), include_blank: t("matches.form.select_prompt"), aria: { label: t("matches.result_entry.board_member", number: board.board_number, team: match_side_name(@match, "home")) } %>
+              <div class="result-entry-cell result-entry-cell--board" data-label="<%= t("labels.board") %>">
+                <div class="result-entry-row__board">#<%= board.board_number %></div>
               </div>
 
-              <div class="field field--compact">
-                <label class="sr-only"><%= t("matches.result_entry.deck_name", team: match_side_name(@match, "home")) %></label>
-                <%= text_field_tag "result_entry[rounds][#{round.number}][boards][#{board.board_number}][home_deck_name]", board.home_deck_name, placeholder: t("matches.result_entry.deck_placeholder"), aria: { label: t("matches.result_entry.deck_name", team: match_side_name(@match, "home")) } %>
-              </div>
-
-              <div class="result-entry-score">
+              <div class="result-entry-cell" data-label="<%= t("matches.result_entry.member_short", team: match_side_name(@match, "home")) %>">
                 <div class="field field--compact">
-                  <label class="sr-only"><%= t("matches.result_entry.game_wins", team: match_side_name(@match, "home")) %></label>
-                  <%= select_tag "result_entry[rounds][#{round.number}][boards][#{board.board_number}][home_game_wins]", options_for_select(game_win_options, board.home_game_wins), include_blank: false, class: "result-entry-score__select", aria: { label: t("matches.result_entry.game_wins", team: match_side_name(@match, "home")) } %>
-                </div>
-                <span class="result-entry-score__sep">-</span>
-                <div class="field field--compact">
-                  <label class="sr-only"><%= t("matches.result_entry.game_wins", team: match_side_name(@match, "away")) %></label>
-                  <%= select_tag "result_entry[rounds][#{round.number}][boards][#{board.board_number}][away_game_wins]", options_for_select(game_win_options, board.away_game_wins), include_blank: false, class: "result-entry-score__select", aria: { label: t("matches.result_entry.game_wins", team: match_side_name(@match, "away")) } %>
+                  <label class="sr-only"><%= t("matches.result_entry.board_member", number: board.board_number, team: match_side_name(@match, "home")) %></label>
+                  <%= select_tag "result_entry[rounds][#{round.number}][boards][#{board.board_number}][home_participant_id]", options_from_collection_for_select(@home_participant_options, :id, :display_name, board.home_participant_id), include_blank: t("matches.form.select_prompt"), aria: { label: t("matches.result_entry.board_member", number: board.board_number, team: match_side_name(@match, "home")) } %>
                 </div>
               </div>
 
-              <div class="field field--compact">
-                <label class="sr-only"><%= t("matches.result_entry.deck_name", team: match_side_name(@match, "away")) %></label>
-                <%= text_field_tag "result_entry[rounds][#{round.number}][boards][#{board.board_number}][away_deck_name]", board.away_deck_name, placeholder: t("matches.result_entry.deck_placeholder"), aria: { label: t("matches.result_entry.deck_name", team: match_side_name(@match, "away")) } %>
+              <div class="result-entry-cell" data-label="<%= t("matches.result_entry.deck_short", team: match_side_name(@match, "home")) %>">
+                <div class="field field--compact">
+                  <label class="sr-only"><%= t("matches.result_entry.deck_name", team: match_side_name(@match, "home")) %></label>
+                  <%= text_field_tag "result_entry[rounds][#{round.number}][boards][#{board.board_number}][home_deck_name]", board.home_deck_name, placeholder: t("matches.result_entry.deck_placeholder"), aria: { label: t("matches.result_entry.deck_name", team: match_side_name(@match, "home")) } %>
+                </div>
               </div>
 
-              <div class="field field--compact">
-                <label class="sr-only"><%= t("matches.result_entry.board_member", number: board.board_number, team: match_side_name(@match, "away")) %></label>
-                <%= select_tag "result_entry[rounds][#{round.number}][boards][#{board.board_number}][away_participant_id]", options_from_collection_for_select(@away_participant_options, :id, :display_name, board.away_participant_id), include_blank: t("matches.form.select_prompt"), aria: { label: t("matches.result_entry.board_member", number: board.board_number, team: match_side_name(@match, "away")) } %>
+              <div class="result-entry-cell" data-label="<%= t("labels.score") %>">
+                <div class="result-entry-score">
+                  <div class="field field--compact">
+                    <label class="sr-only"><%= t("matches.result_entry.game_wins", team: match_side_name(@match, "home")) %></label>
+                    <%= select_tag "result_entry[rounds][#{round.number}][boards][#{board.board_number}][home_game_wins]", options_for_select(game_win_options, board.home_game_wins), include_blank: false, class: "result-entry-score__select", aria: { label: t("matches.result_entry.game_wins", team: match_side_name(@match, "home")) } %>
+                  </div>
+                  <span class="result-entry-score__sep">-</span>
+                  <div class="field field--compact">
+                    <label class="sr-only"><%= t("matches.result_entry.game_wins", team: match_side_name(@match, "away")) %></label>
+                    <%= select_tag "result_entry[rounds][#{round.number}][boards][#{board.board_number}][away_game_wins]", options_for_select(game_win_options, board.away_game_wins), include_blank: false, class: "result-entry-score__select", aria: { label: t("matches.result_entry.game_wins", team: match_side_name(@match, "away")) } %>
+                  </div>
+                </div>
+              </div>
+
+              <div class="result-entry-cell" data-label="<%= t("matches.result_entry.deck_short", team: match_side_name(@match, "away")) %>">
+                <div class="field field--compact">
+                  <label class="sr-only"><%= t("matches.result_entry.deck_name", team: match_side_name(@match, "away")) %></label>
+                  <%= text_field_tag "result_entry[rounds][#{round.number}][boards][#{board.board_number}][away_deck_name]", board.away_deck_name, placeholder: t("matches.result_entry.deck_placeholder"), aria: { label: t("matches.result_entry.deck_name", team: match_side_name(@match, "away")) } %>
+                </div>
+              </div>
+
+              <div class="result-entry-cell" data-label="<%= t("matches.result_entry.member_short", team: match_side_name(@match, "away")) %>">
+                <div class="field field--compact">
+                  <label class="sr-only"><%= t("matches.result_entry.board_member", number: board.board_number, team: match_side_name(@match, "away")) %></label>
+                  <%= select_tag "result_entry[rounds][#{round.number}][boards][#{board.board_number}][away_participant_id]", options_from_collection_for_select(@away_participant_options, :id, :display_name, board.away_participant_id), include_blank: t("matches.form.select_prompt"), aria: { label: t("matches.result_entry.board_member", number: board.board_number, team: match_side_name(@match, "away")) } %>
+                </div>
               </div>
             </div>
           <% end %>

--- a/apps/ledger/app/views/matches/show.html.erb
+++ b/apps/ledger/app/views/matches/show.html.erb
@@ -38,6 +38,13 @@
   </div>
 </section>
 
+<% if @match.ready_for_result_entry? %>
+  <p class="muted">
+    <%= status_badge(result_card_export_status_label(@result_card_export_state), result_card_export_status_tone(@result_card_export_state)) %>
+    <%= result_card_export_hint(@result_card_export_state) %>
+  </p>
+<% end %>
+
 <section class="dashboard-grid">
   <article class="panel">
     <h2><%= t("matches.progress") %></h2>

--- a/apps/ledger/config/locales/en.yml
+++ b/apps/ledger/config/locales/en.yml
@@ -709,7 +709,7 @@ en:
         board_result:
           attributes:
             base:
-              invalid_game_score_pattern: Game score must be one of 2-0, 2-1, 1-2, or 0-2.
+              invalid_game_score_pattern: Game score must be one of 2-0, 2-1, 1-1, 1-2, or 0-2.
   helpers:
     submit:
       create: "Create %{model}"

--- a/apps/ledger/config/locales/en.yml
+++ b/apps/ledger/config/locales/en.yml
@@ -142,6 +142,9 @@ en:
       bracket_progress_locked: The next bracket card already has a result, so advancement cannot be updated.
       lineup_updated: Order updated.
       results_updated: Match result updated.
+      results_updated_with_export: Match result updated. Background image generation has started.
+      export_generation_started: Image generation has started. Please wait a moment and try downloading again.
+      export_refresh_started: Refreshing the latest image has started. Please wait a moment and try downloading again.
       export_failed: Failed to generate the match image. Please try again in a moment.
       export_timeout: Match image generation timed out. Please wait a moment and try again.
     standings:
@@ -476,7 +479,17 @@ en:
     progress: Progress
     official_result: Official result
     result_card: Result image
-    result_card_download: The latest image is generated when you download it.
+    result_card_download: The image is generated in the background after results are saved.
+    result_card_status:
+      missing: Not generated
+      pending: Generating
+      stale: Refreshing
+      generated: Ready
+    result_card_hint:
+      missing: The image is generated automatically after results are saved. You can also start it by downloading.
+      pending: The image is being generated. Please wait a moment and try downloading again.
+      stale: The image is being refreshed with the latest result. Please wait a moment and try downloading again.
+      generated: The latest image is ready to download.
     rounds: Rounds
     empty_result: No official result yet.
     empty_rounds: No rounds yet.

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -709,7 +709,7 @@ ja:
         board_result:
           attributes:
             base:
-              invalid_game_score_pattern: ゲーム数は 2-0, 2-1, 1-2, 0-2 のいずれかで入力してください。
+              invalid_game_score_pattern: ゲーム数は 2-0, 2-1, 1-1, 1-2, 0-2 のいずれかで入力してください。
   helpers:
     submit:
       create: "%{model}を作成"

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -99,14 +99,14 @@ ja:
       created: チームを作成しました。
       updated: チームを更新しました。
       deleted: チームを削除しました。
-      delete_blocked: このチームは対戦で使われているため削除できません。公開後の離脱は状態をドロップに変更してください。
+      delete_blocked: このチームは対戦で使われているため削除できません。実施中の離脱は状態をドロップに変更してください。
     team_imports:
       created: "CSVを取り込みました。チーム %{created_teams}件追加 / %{updated_teams}件更新、メンバー %{created_participants}件追加 / %{updated_participants}件更新。"
     participants:
       created: メンバーを作成しました。
       updated: メンバーを更新しました。
       deleted: メンバーを削除しました。
-      delete_blocked: このメンバーは試合結果で使われているため削除できません。公開後は削除せず残します。
+      delete_blocked: このメンバーは試合結果で使われているため削除できません。実施中は削除せず残します。
     phases:
       created: フェーズを作成しました。
       updated: フェーズを更新しました。
@@ -249,7 +249,7 @@ ja:
       block: ブロック
       no_block: 未設定
       status: 状態
-      status_hint: "%{draft_label} のリーグでは削除できます。公開後の離脱は %{withdrawn_label} を使います。"
+      status_hint: "%{draft_label} のリーグでは削除できます。実施中の離脱は %{withdrawn_label} を使います。"
       notes: メモ
     delete_confirm: このチームを削除します。よろしいですか？
     delete_hint: 対戦で未使用のチームだけ削除できます。
@@ -580,7 +580,7 @@ ja:
     league:
       status:
         draft: 下書き
-        active: 公開中
+        active: 実施中
         completed: 完了
     organizer_member:
       role:

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -142,6 +142,9 @@ ja:
       bracket_progress_locked: 次のカードに結果が入っているため、勝ち上がり先を更新できません。
       lineup_updated: オーダーを更新しました。
       results_updated: 対戦結果を更新しました。
+      results_updated_with_export: 対戦結果を更新しました。画像生成をバックグラウンドで開始しました。
+      export_generation_started: 画像生成を開始しました。少し待ってから再度ダウンロードしてください。
+      export_refresh_started: 最新画像への更新を開始しました。少し待ってから再度ダウンロードしてください。
       export_failed: 対戦画像の出力に失敗しました。時間をおいて再度お試しください。
       export_timeout: 対戦画像の出力がタイムアウトしました。少し待ってから再度お試しください。
     standings:
@@ -476,7 +479,17 @@ ja:
     progress: 進行状況
     official_result: 公式結果
     result_card: 結果画像
-    result_card_download: ダウンロード時に最新画像を生成します。
+    result_card_download: 結果保存後に画像をバックグラウンド生成します。
+    result_card_status:
+      missing: 未生成
+      pending: 生成中
+      stale: 更新待ち
+      generated: 生成済み
+    result_card_hint:
+      missing: 結果保存後に自動生成されます。必要ならダウンロード操作でも生成を開始できます。
+      pending: 画像を生成中です。少し待ってから再度ダウンロードしてください。
+      stale: 最新結果へ更新中です。少し待ってから再度ダウンロードしてください。
+      generated: 最新画像をすぐダウンロードできます。
     rounds: ラウンド
     empty_result: 公式結果はまだありません。
     empty_rounds: ラウンドはまだありません。

--- a/apps/ledger/test/integration/regular_season_operations_flow_test.rb
+++ b/apps/ledger/test/integration/regular_season_operations_flow_test.rb
@@ -189,6 +189,50 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
     assert_equal "pending", export.status
   end
 
+  test "organizer can confirm a regular season match at 1-1 when all rounds are completed" do
+    login_as!(@organizer_account, password: @password)
+
+    league = @organizer_account.leagues.create!(
+      name: "Draw League",
+      status: "draft",
+      roster_min_members: 4,
+      roster_max_members: 8,
+      lineup_size: 3,
+      substitute_size: 1
+    )
+    phase = league.phases.create!(name: "予選 1", stage_asset: regular_stage_asset, position: 1)
+    block = phase.blocks.create!(league:, name: "Block A", position: 1)
+    week = phase.weeks.create!(league:, number: 1, position: 1)
+    team_a = create_team_record_with_members!(league:, name: "Draw Team A")
+    team_b = create_team_record_with_members!(league:, name: "Draw Team B")
+    match = week.matches.create!(
+      league: league,
+      phase: phase,
+      block: block,
+      home_team: team_a,
+      away_team: team_b,
+      scheduled_on: Date.new(2026, 4, 11),
+      scheduled_time: Time.zone.parse("20:00"),
+      status: "scheduled"
+    )
+
+    patch match_result_entry_path(locale: :ja, match_id: match), params: {
+      result_entry: {
+        rounds: draw_result_payload(match)
+      }
+    }
+
+    assert_redirected_to edit_match_result_entry_path(locale: :ja, match_id: match)
+
+    match.reload
+    assert_equal "confirmed", match.status
+    assert_equal [1, 1], [match.match_result.home_round_wins, match.match_result.away_round_wins]
+    assert_nil match.match_result.winner_team
+    assert_equal "confirmed", match.match_result.result_status
+    assert_equal [true, true, true], match.rounds.order(:number).map(&:confirmed?)
+    assert_equal [team_a, team_b, nil], match.rounds.order(:number).map(&:winner_team)
+  end
+
   test "organizer can create a tournament phase before setting participant count" do
     login_as!(@organizer_account, password: @password)
 
@@ -839,6 +883,17 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
       "1" => round_payload(home:, away:, scores: [[2, 0], [2, 1], [0, 2]], suffix: "R1"),
       "2" => round_payload(home:, away:, scores: [[2, 0], [2, 1], [0, 2]], suffix: "R2"),
       "3" => round_payload(home:, away:, scores: [[0, 2], [1, 2], [2, 0]], suffix: "R3")
+    }
+  end
+
+  def draw_result_payload(match)
+    home = match.home_team.participants.order(:position)
+    away = match.away_team.participants.order(:position)
+
+    {
+      "1" => round_payload(home:, away:, scores: [[2, 0], [2, 1], [0, 2]], suffix: "D1"),
+      "2" => round_payload(home:, away:, scores: [[0, 2], [1, 2], [2, 0]], suffix: "D2"),
+      "3" => round_payload(home:, away:, scores: [[2, 0], [0, 2], [1, 1]], suffix: "D3")
     }
   end
 

--- a/apps/ledger/test/integration/regular_season_operations_flow_test.rb
+++ b/apps/ledger/test/integration/regular_season_operations_flow_test.rb
@@ -161,6 +161,10 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
       substitute_size: 1
     )
 
+    get edit_league_path(locale: :ja, id: league)
+    assert_response :success
+    assert_select %(form[action="#{league_path(locale: :ja, id: league)}"])
+
     patch league_path(locale: :ja, id: league), params: {
       league: {
         name: league.name,

--- a/apps/ledger/test/integration/regular_season_operations_flow_test.rb
+++ b/apps/ledger/test/integration/regular_season_operations_flow_test.rb
@@ -149,6 +149,35 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
     assert_includes response.headers["Content-Disposition"], "attachment"
   end
 
+  test "organizer can reopen a completed league by changing it back to active" do
+    login_as!(@organizer_account, password: @password)
+
+    league = @organizer_account.leagues.create!(
+      name: "Reopenable League",
+      status: "completed",
+      roster_min_members: 4,
+      roster_max_members: 8,
+      lineup_size: 3,
+      substitute_size: 1
+    )
+
+    patch league_path(locale: :ja, id: league), params: {
+      league: {
+        name: league.name,
+        status: "active",
+        roster_min_members: league.roster_min_members,
+        roster_max_members: league.roster_max_members,
+        lineup_size: league.lineup_size,
+        substitute_size: league.substitute_size,
+        started_at: "",
+        ended_at: ""
+      }
+    }
+
+    assert_redirected_to league_path(locale: :ja, id: league)
+    assert_equal "active", league.reload.status
+  end
+
   test "downloading without a fresh export queues background generation" do
     login_as!(@organizer_account, password: @password)
 

--- a/apps/ledger/test/integration/regular_season_operations_flow_test.rb
+++ b/apps/ledger/test/integration/regular_season_operations_flow_test.rb
@@ -3,7 +3,14 @@ require "stringio"
 require "test_helper"
 
 class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
+  include ActiveJob::TestHelper
+
   setup do
+    @original_queue_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :test
+    clear_enqueued_jobs
+    clear_performed_jobs
+
     @password = "password"
     @organizer_account = OrganizerAccount.create!(
       display_name: "E2E Organizer",
@@ -23,6 +30,12 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
       active: true
     )
     @organizer_account.ensure_default_stage_assets!
+  end
+
+  teardown do
+    clear_enqueued_jobs
+    clear_performed_jobs
+    ActiveJob::Base.queue_adapter = @original_queue_adapter
   end
 
   test "organizer can run the regular season flow end to end" do
@@ -108,11 +121,13 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
     }
     assert_redirected_to dashboard_path(locale: :ja)
 
-    patch match_result_entry_path(locale: :ja, match_id: match), params: {
-      result_entry: {
-        rounds: result_payload(match)
+    assert_enqueued_with(job: MatchExports::GenerateResultCardJob, args: [match.id]) do
+      patch match_result_entry_path(locale: :ja, match_id: match), params: {
+        result_entry: {
+          rounds: result_payload(match)
+        }
       }
-    }
+    end
     assert_redirected_to edit_match_result_entry_path(locale: :ja, match_id: match)
 
     match.reload
@@ -123,13 +138,18 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
     assert_equal 3, match.rounds.count
     assert_equal 9, match.rounds.sum { |round| round.board_results.count }
 
-    get download_match_result_card_export_path(locale: :ja, match_id: match)
+    MatchExports::GenerateResultCardJob.perform_now(match.id)
+    clear_enqueued_jobs
+
+    assert_no_enqueued_jobs only: MatchExports::GenerateResultCardJob do
+      get download_match_result_card_export_path(locale: :ja, match_id: match)
+    end
     assert_response :success
     assert_equal "image/png", response.media_type
     assert_includes response.headers["Content-Disposition"], "attachment"
   end
 
-  test "match export timeout shows a localized alert instead of raw exception text" do
+  test "downloading without a fresh export queues background generation" do
     login_as!(@organizer_account, password: @password)
 
     league = @organizer_account.leagues.create!(
@@ -156,28 +176,17 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
       status: "scheduled"
     )
 
-    timeout_renderer = Object.new
-    def timeout_renderer.render!
-      raise Ferrum::TimeoutError, "Timed out waiting for response."
-    end
-
-    renderer_singleton = MatchExports::ResultCardRenderer.singleton_class
-    original_new = MatchExports::ResultCardRenderer.method(:new)
-    renderer_singleton.send(:define_method, :new) do |*|
-      timeout_renderer
-    end
-
-    begin
+    assert_enqueued_with(job: MatchExports::GenerateResultCardJob, args: [match.id]) do
       get download_match_result_card_export_path(locale: :ja, match_id: match)
-    ensure
-      renderer_singleton.send(:define_method, :new, original_new)
     end
 
     assert_redirected_to match_path(locale: :ja, id: match)
     follow_redirect!
     assert_response :success
-    assert_includes response.body, "対戦画像の出力がタイムアウトしました。少し待ってから再度お試しください。"
-    refute_includes response.body, "Timed out waiting for response"
+    assert_includes response.body, "画像生成を開始しました。少し待ってから再度ダウンロードしてください。"
+
+    export = match.exports.find_by!(export_type: MatchExports::ResultCardRenderer::EXPORT_TYPE)
+    assert_equal "pending", export.status
   end
 
   test "organizer can create a tournament phase before setting participant count" do

--- a/apps/ledger/test/integration/regular_season_operations_flow_test.rb
+++ b/apps/ledger/test/integration/regular_season_operations_flow_test.rb
@@ -175,6 +175,9 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
     }
 
     assert_redirected_to league_path(locale: :ja, id: league)
+    follow_redirect!
+    assert_response :success
+    assert_includes response.body, "実施中"
     assert_equal "active", league.reload.status
   end
 

--- a/apps/ledger/test/jobs/match_exports/generate_result_card_job_test.rb
+++ b/apps/ledger/test/jobs/match_exports/generate_result_card_job_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class MatchExports::GenerateResultCardJobTest < ActiveJob::TestCase
+  test "job discards missing records" do
+    assert_nothing_raised do
+      MatchExports::GenerateResultCardJob.perform_now(SecureRandom.uuid)
+    end
+  end
+end

--- a/apps/ledger/test/models/board_result_test.rb
+++ b/apps/ledger/test/models/board_result_test.rb
@@ -28,6 +28,22 @@ class BoardResultTest < ActiveSupport::TestCase
     end
   end
 
+  test "1-1 is treated as a confirmed draw without winner_side" do
+    round = create_round_for_board_result_test!
+
+    board_result = round.board_results.build(
+      board_number: 1,
+      home_game_wins: 1,
+      away_game_wins: 1,
+      result_status: "confirmed",
+      winner_side: BoardResult.infer_winner_side(1, 1)
+    )
+
+    assert board_result.valid?
+    assert_nil board_result.winner_side
+    assert board_result.confirmed_score?
+  end
+
   private
 
   def create_round_for_board_result_test!


### PR DESCRIPTION
## Summary
- allow 1-1 regular-season results and improve mobile result entry behavior
- fix the league edit form action so completed leagues can be moved back to active/ongoing from the UI
- rename the active league label to 実施中 and disable the sticky topbar on small screens
- include the result card export fixes currently on staging

## Verification
- RBENV_VERSION=3.4.9 bundle exec rails test test/integration/regular_season_operations_flow_test.rb
- staging verification of DEMO WMGP Season 7.5 status transitions via the fixed edit form
- staging confirmation data prepared for in_progress / result_pending / confirmed 1-1 cases