### PR TITLE
Make result entry save resilient to export queue errors

### DIFF
--- a/apps/ledger/app/controllers/match_result_entries_controller.rb
+++ b/apps/ledger/app/controllers/match_result_entries_controller.rb
@@ -10,13 +10,20 @@ class MatchResultEntriesController < ApplicationController
     MatchResults::Recorder.new(@match, result_entry_params).save!
     @match.update_column(:judge_name, current_organizer_member.display_name)
     Brackets::ProgressionSync.new(@match).sync!
-    MatchExports::ResultCardExportManager.new(@match).enqueue_refresh!
-    redirect_to edit_match_result_entry_path(match_id: @match), notice: t("flash.matches.results_updated_with_export")
+    export_refresh_failed = enqueue_result_card_refresh_failed?
+
+    redirect_to(
+      edit_match_result_entry_path(match_id: @match),
+      notice: t("flash.matches.results_updated_with_export"),
+      alert: export_refresh_failed ? t("flash.matches.export_refresh_failed_non_blocking") : nil
+    )
   rescue Brackets::ProgressionSync::LockedError => error
+    Rails.logger.warn("Result entry progression sync blocked for match=#{@match.id}: #{error.message}")
     flash.now[:alert] = error.message
     set_result_form_state
     render :edit, status: :unprocessable_entity
   rescue ActiveRecord::RecordInvalid => error
+    log_record_invalid(error)
     flash.now[:alert] = error.record.errors.full_messages.to_sentence
     set_result_form_state
     render :edit, status: :unprocessable_entity
@@ -55,5 +62,21 @@ class MatchResultEntriesController < ApplicationController
     return {} unless params[:result_entry].is_a?(ActionController::Parameters)
 
     params.require(:result_entry).permit!.to_h
+  end
+
+  def enqueue_result_card_refresh_failed?
+    MatchExports::ResultCardExportManager.new(@match).enqueue_refresh!
+    false
+  rescue StandardError => error
+    Rails.logger.error("Result card refresh enqueue failed for match=#{@match.id}: #{error.class}: #{error.message}")
+    true
+  end
+
+  def log_record_invalid(error)
+    record = error.record
+    messages = record&.errors&.full_messages&.join(" / ")
+    Rails.logger.warn(
+      "Result entry save failed for match=#{@match.id}: #{error.class} on #{record&.class || 'unknown'}: #{messages.presence || error.message}"
+    )
   end
 end

--- a/apps/ledger/config/locales/en.yml
+++ b/apps/ledger/config/locales/en.yml
@@ -143,6 +143,7 @@ en:
       lineup_updated: Order updated.
       results_updated: Match result updated.
       results_updated_with_export: Match result updated. Background image generation has started.
+      export_refresh_failed_non_blocking: Match result was saved, but image refresh could not be started. Please try saving again in a moment.
       export_generation_started: Image generation has started. Please wait a moment and try downloading again.
       export_refresh_started: Refreshing the latest image has started. Please wait a moment and try downloading again.
       export_failed: Failed to generate the match image. Please try again in a moment.

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -143,6 +143,7 @@ ja:
       lineup_updated: オーダーを更新しました。
       results_updated: 対戦結果を更新しました。
       results_updated_with_export: 対戦結果を更新しました。画像生成をバックグラウンドで開始しました。
+      export_refresh_failed_non_blocking: 対戦結果は保存しましたが、画像更新の開始に失敗しました。時間をおいて再度保存してください。
       export_generation_started: 画像生成を開始しました。少し待ってから再度ダウンロードしてください。
       export_refresh_started: 最新画像への更新を開始しました。少し待ってから再度ダウンロードしてください。
       export_failed: 対戦画像の出力に失敗しました。時間をおいて再度お試しください。

--- a/apps/ledger/test/integration/regular_season_operations_flow_test.rb
+++ b/apps/ledger/test/integration/regular_season_operations_flow_test.rb
@@ -269,6 +269,58 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
     assert_equal [team_a, team_b, nil], match.rounds.order(:number).map(&:winner_team)
   end
 
+  test "result entry stays saved when export refresh enqueue fails" do
+    login_as!(@organizer_account, password: @password)
+
+    league = @organizer_account.leagues.create!(
+      name: "Export Retry League",
+      status: "draft",
+      roster_min_members: 4,
+      roster_max_members: 8,
+      lineup_size: 3,
+      substitute_size: 1
+    )
+    phase = league.phases.create!(name: "予選 1", stage_asset: regular_stage_asset, position: 1)
+    block = phase.blocks.create!(league:, name: "Block A", position: 1)
+    week = phase.weeks.create!(league:, number: 1, position: 1)
+    team_a = create_team_record_with_members!(league:, name: "Retry Team A")
+    team_b = create_team_record_with_members!(league:, name: "Retry Team B")
+    match = week.matches.create!(
+      league: league,
+      phase: phase,
+      block: block,
+      home_team: team_a,
+      away_team: team_b,
+      scheduled_on: Date.new(2026, 4, 11),
+      scheduled_time: Time.zone.parse("20:00"),
+      status: "scheduled"
+    )
+
+    manager = Object.new
+    manager.define_singleton_method(:enqueue_refresh!) { raise StandardError, "job queue unavailable" }
+
+    original_new = MatchExports::ResultCardExportManager.method(:new)
+    MatchExports::ResultCardExportManager.define_singleton_method(:new) { |_| manager }
+
+    begin
+      patch match_result_entry_path(locale: :ja, match_id: match), params: {
+        result_entry: {
+          rounds: result_payload(match)
+        }
+      }
+    ensure
+      MatchExports::ResultCardExportManager.define_singleton_method(:new, original_new)
+    end
+
+    assert_redirected_to edit_match_result_entry_path(locale: :ja, match_id: match)
+    assert_equal I18n.t("flash.matches.results_updated_with_export"), flash[:notice]
+    assert_equal I18n.t("flash.matches.export_refresh_failed_non_blocking"), flash[:alert]
+
+    match.reload
+    assert_equal "confirmed", match.status
+    assert_equal [2, 1], [match.match_result.home_round_wins, match.match_result.away_round_wins]
+  end
+
   test "organizer can create a tournament phase before setting participant count" do
     login_as!(@organizer_account, password: @password)
 


### PR DESCRIPTION
## Summary
- keep match result entry saved even if result card refresh enqueue fails
- log record validation failures in result entry updates for easier production diagnosis
- add integration coverage for the non-blocking export refresh failure path

## Testing
- bundle exec rails test test/integration/regular_season_operations_flow_test.rb test/models/board_result_test.rb