### PR TITLE
Recompute result card winners from board scores

### DIFF
--- a/apps/ledger/app/services/match_exports/result_card_renderer.rb
+++ b/apps/ledger/app/services/match_exports/result_card_renderer.rb
@@ -389,7 +389,7 @@ module MatchExports
 
     def round_result_html(round)
       home_label, away_label =
-        case round&.winner_team_id
+        case resolved_round_winner_team_id(round)
         when match.home_team_id then ["W", "L"]
         when match.away_team_id then ["L", "W"]
         else ["-", "-"]
@@ -403,9 +403,7 @@ module MatchExports
     end
 
     def footer_html
-      result = match.match_result
-      home_score = result&.home_round_wins.to_i
-      away_score = result&.away_round_wins.to_i
+      home_score, away_score = resolved_match_score
       <<~HTML
         <div class="footer">
           <div class="footer-team home">#{h match.home_team.display_name}</div>
@@ -429,6 +427,38 @@ module MatchExports
 
     def week_label
       match.bracket_match? ? match.bracket_slot_label : match.week.display_name
+    end
+
+    def resolved_round_winner_team_id(round)
+      return nil unless round
+      return round.winner_team_id if round.winner_team_id.present?
+
+      boards = round.board_results.to_a
+      return nil unless boards.size == 3
+      return nil unless boards.all?(&:confirmed_score?)
+
+      home_wins = boards.count { |board| resolved_board_winner_side(board) == "home" }
+      away_wins = boards.count { |board| resolved_board_winner_side(board) == "away" }
+
+      if home_wins > away_wins
+        match.home_team_id
+      elsif away_wins > home_wins
+        match.away_team_id
+      end
+    end
+
+    def resolved_match_score
+      rounds = match.rounds.index_by(&:number)
+      round_winners = (1..3).map { |round_number| resolved_round_winner_team_id(rounds[round_number]) }
+
+      [
+        round_winners.count(match.home_team_id),
+        round_winners.count(match.away_team_id)
+      ]
+    end
+
+    def resolved_board_winner_side(board)
+      board.winner_side.presence || board.inferred_winner_side
     end
 
     def scheduled_label

--- a/apps/ledger/test/services/match_exports/result_card_renderer_test.rb
+++ b/apps/ledger/test/services/match_exports/result_card_renderer_test.rb
@@ -2,14 +2,67 @@ require "test_helper"
 
 class MatchExports::ResultCardRendererTest < ActiveSupport::TestCase
   test "versus header uses VS label" do
+    match = create_match_for_renderer_test!(home_name: "Alpha Team", away_name: "Beta Team")
+
+    html = MatchExports::ResultCardRenderer.new(match).send(:versus_html)
+
+    assert_includes html, ">VS<"
+    assert_not_includes html, ">対<"
+  end
+
+  test "renderer falls back to board scores when stored winners are stale" do
+    match = create_match_for_renderer_test!(home_name: "StardustHope", away_name: "ST | KnikxLaw")
+    round_one = match.rounds.create!(
+      number: 1,
+      home_team: match.home_team,
+      away_team: match.away_team,
+      result_status: "partial",
+      winner_team: nil
+    )
+    round_two = match.rounds.create!(
+      number: 2,
+      home_team: match.home_team,
+      away_team: match.away_team,
+      result_status: "confirmed",
+      winner_team: match.home_team
+    )
+
+    create_confirmed_board_result!(round: round_one, board_number: 1, score: [2, 0], winner_side: nil)
+    create_confirmed_board_result!(round: round_one, board_number: 2, score: [2, 0], winner_side: nil)
+    create_confirmed_board_result!(round: round_one, board_number: 3, score: [2, 0], winner_side: nil)
+    create_confirmed_board_result!(round: round_two, board_number: 1, score: [2, 1], winner_side: "home")
+    create_confirmed_board_result!(round: round_two, board_number: 2, score: [2, 1], winner_side: "home")
+    create_confirmed_board_result!(round: round_two, board_number: 3, score: [1, 2], winner_side: "away")
+
+    match.create_match_result!(
+      home_round_wins: 1,
+      away_round_wins: 0,
+      winner_team: match.home_team,
+      result_status: "partial",
+      decision_type: "normal"
+    )
+
+    renderer = MatchExports::ResultCardRenderer.new(match.reload)
+
+    round_one_html = renderer.send(:round_result_html, match.rounds.find_by!(number: 1))
+    footer_html = renderer.send(:footer_html)
+
+    assert_includes round_one_html, '<span class="win">W</span>'
+    assert_includes round_one_html, '<span class="lose">L</span>'
+    assert_includes footer_html, '<div class="footer-score">2 - 0</div>'
+  end
+
+  private
+
+  def create_match_for_renderer_test!(home_name:, away_name:)
     organizer = OrganizerAccount.create!(
       display_name: "Renderer Organizer",
-      login_id: "renderer-org",
-      email: "renderer@example.com",
+      login_id: "renderer-org-#{SecureRandom.hex(4)}",
+      email: "renderer-#{SecureRandom.hex(4)}@example.com",
       password: "password"
     )
     league = organizer.leagues.create!(
-      name: "Renderer League",
+      name: "Renderer League #{SecureRandom.hex(4)}",
       status: "active",
       roster_min_members: 4,
       roster_max_members: 8,
@@ -18,9 +71,10 @@ class MatchExports::ResultCardRendererTest < ActiveSupport::TestCase
     )
     phase = league.phases.create!(name: "予選 1", position: 1, rule_module_key: "wmgp")
     week = phase.weeks.create!(league: league, number: 1, position: 1)
-    home_team = league.teams.create!(display_name: "Alpha Team")
-    away_team = league.teams.create!(display_name: "Beta Team")
-    match = week.matches.create!(
+    home_team = league.teams.create!(display_name: home_name)
+    away_team = league.teams.create!(display_name: away_name)
+
+    week.matches.create!(
       league: league,
       phase: phase,
       home_team: home_team,
@@ -29,10 +83,15 @@ class MatchExports::ResultCardRendererTest < ActiveSupport::TestCase
       scheduled_time: Time.zone.parse("20:00"),
       status: "scheduled"
     )
+  end
 
-    html = MatchExports::ResultCardRenderer.new(match).send(:versus_html)
-
-    assert_includes html, ">VS<"
-    assert_not_includes html, ">対<"
+  def create_confirmed_board_result!(round:, board_number:, score:, winner_side:)
+    round.board_results.create!(
+      board_number: board_number,
+      home_game_wins: score[0],
+      away_game_wins: score[1],
+      result_status: "confirmed",
+      winner_side: winner_side
+    )
   end
 end


### PR DESCRIPTION
## Summary
- recalculate result card round winners from board scores when stored winner aggregates are stale
- recalculate the footer match score from rendered rounds for consistency
- add renderer coverage for stale aggregate fallback

## Testing
- bundle exec rails test test/services/match_exports/result_card_renderer_test.rb test/integration/regular_season_operations_flow_test.rb test/models/board_result_test.rb