### PR TITLE
Update Google deploy actions to v3

### DIFF
--- a/.github/workflows/deploy-google.yml
+++ b/.github/workflows/deploy-google.yml
@@ -26,13 +26,13 @@ jobs:
       - uses: actions/checkout@v5
 
       - id: auth
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
           create_credentials_file: true
 
-      - uses: google-github-actions/setup-gcloud@v2
+      - uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ env.GOOGLE_CLOUD_PROJECT }}
 


### PR DESCRIPTION
## Summary
- update `google-github-actions/auth` from `v2` to `v3`
- update `google-github-actions/setup-gcloud` from `v2` to `v3`
- remove the Node 20 deprecation warning from the deploy workflow

## Validation
- workflow YAML loads successfully
- updated staging deploy workflow completed successfully with `auth@v3` and `setup-gcloud@v3`
- staging service remained healthy after the workflow update