### PR TITLE
Promote staging to main

### DIFF
--- a/apps/ledger/.gitignore
+++ b/apps/ledger/.gitignore
@@ -31,6 +31,7 @@
 /public/assets
 /public/generated/*
 /vendor/bundle/
+/.bundle_home/
 
 # Ignore key files for decrypting credentials and more.
 /config/*.key

--- a/apps/ledger/app/models/board_result.rb
+++ b/apps/ledger/app/models/board_result.rb
@@ -40,7 +40,7 @@ class BoardResult < ApplicationRecord
   def self.valid_confirmed_score?(home_game_wins, away_game_wins)
     return false if home_game_wins.nil? || away_game_wins.nil?
 
-    [[2, 0], [2, 1], [1, 1], [1, 2], [0, 2]].include?([home_game_wins, away_game_wins])
+    [[2, 0], [2, 1], [1, 0], [1, 1], [0, 1], [1, 2], [0, 2]].include?([home_game_wins, away_game_wins])
   end
 
   private

--- a/apps/ledger/config/locales/en.yml
+++ b/apps/ledger/config/locales/en.yml
@@ -710,7 +710,7 @@ en:
         board_result:
           attributes:
             base:
-              invalid_game_score_pattern: Game score must be one of 2-0, 2-1, 1-1, 1-2, or 0-2.
+              invalid_game_score_pattern: Game score must be one of 2-0, 2-1, 1-0, 1-1, 0-1, 1-2, or 0-2.
   helpers:
     submit:
       create: "Create %{model}"

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -710,7 +710,7 @@ ja:
         board_result:
           attributes:
             base:
-              invalid_game_score_pattern: ゲーム数は 2-0, 2-1, 1-1, 1-2, 0-2 のいずれかで入力してください。
+              invalid_game_score_pattern: ゲーム数は 2-0, 2-1, 1-0, 1-1, 0-1, 1-2, 0-2 のいずれかで入力してください。
   helpers:
     submit:
       create: "%{model}を作成"

--- a/apps/ledger/test/integration/regular_season_operations_flow_test.rb
+++ b/apps/ledger/test/integration/regular_season_operations_flow_test.rb
@@ -269,6 +269,47 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
     assert_equal [team_a, team_b, nil], match.rounds.order(:number).map(&:winner_team)
   end
 
+  test "organizer can save 1-0 and 0-1 board scores" do
+    login_as!(@organizer_account, password: @password)
+
+    league = @organizer_account.leagues.create!(
+      name: "Short Score League",
+      status: "draft",
+      roster_min_members: 4,
+      roster_max_members: 8,
+      lineup_size: 3,
+      substitute_size: 1
+    )
+    phase = league.phases.create!(name: "予選 1", stage_asset: regular_stage_asset, position: 1)
+    block = phase.blocks.create!(league:, name: "Block A", position: 1)
+    week = phase.weeks.create!(league:, number: 1, position: 1)
+    team_a = create_team_record_with_members!(league:, name: "Short Team A")
+    team_b = create_team_record_with_members!(league:, name: "Short Team B")
+    match = week.matches.create!(
+      league: league,
+      phase: phase,
+      block: block,
+      home_team: team_a,
+      away_team: team_b,
+      scheduled_on: Date.new(2026, 4, 13),
+      scheduled_time: Time.zone.parse("20:00"),
+      status: "scheduled"
+    )
+
+    patch match_result_entry_path(locale: :ja, match_id: match), params: {
+      result_entry: {
+        rounds: short_score_result_payload(match)
+      }
+    }
+
+    assert_redirected_to edit_match_result_entry_path(locale: :ja, match_id: match)
+
+    match.reload
+    assert_equal "confirmed", match.status
+    assert_equal [1, 1], [match.match_result.home_round_wins, match.match_result.away_round_wins]
+    assert_equal [[1, 0], [0, 1], [1, 1]], match.rounds.order(:number).last.board_results.order(:board_number).pluck(:home_game_wins, :away_game_wins)
+  end
+
   test "result entry stays saved when export refresh enqueue fails" do
     login_as!(@organizer_account, password: @password)
 
@@ -982,6 +1023,17 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
       "1" => round_payload(home:, away:, scores: [[2, 0], [2, 1], [0, 2]], suffix: "D1"),
       "2" => round_payload(home:, away:, scores: [[0, 2], [1, 2], [2, 0]], suffix: "D2"),
       "3" => round_payload(home:, away:, scores: [[2, 0], [0, 2], [1, 1]], suffix: "D3")
+    }
+  end
+
+  def short_score_result_payload(match)
+    home = match.home_team.participants.order(:position)
+    away = match.away_team.participants.order(:position)
+
+    {
+      "1" => round_payload(home:, away:, scores: [[1, 0], [1, 0], [0, 1]], suffix: "S1"),
+      "2" => round_payload(home:, away:, scores: [[0, 1], [0, 1], [1, 0]], suffix: "S2"),
+      "3" => round_payload(home:, away:, scores: [[1, 0], [0, 1], [1, 1]], suffix: "S3")
     }
   end
 

--- a/apps/ledger/test/models/board_result_test.rb
+++ b/apps/ledger/test/models/board_result_test.rb
@@ -44,6 +44,16 @@ class BoardResultTest < ActiveSupport::TestCase
     assert board_result.confirmed_score?
   end
 
+  test "1-0 is treated as a confirmed home win" do
+    assert BoardResult.valid_confirmed_score?(1, 0)
+    assert_equal "home", BoardResult.infer_winner_side(1, 0)
+  end
+
+  test "0-1 is treated as a confirmed away win" do
+    assert BoardResult.valid_confirmed_score?(0, 1)
+    assert_equal "away", BoardResult.infer_winner_side(0, 1)
+  end
+
   private
 
   def create_round_for_board_result_test!

--- a/scripts/deploy-cloudrun-ledger.sh
+++ b/scripts/deploy-cloudrun-ledger.sh
@@ -101,3 +101,8 @@ gcloud run deploy "$CLOUD_RUN_SERVICE" \
   --port 8080 \
   --add-cloudsql-instances "$CLOUD_SQL_INSTANCE" \
   --env-vars-file "$RUNTIME_ENV_FILE"
+
+gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+  --project "$GOOGLE_CLOUD_PROJECT" \
+  --region "$GOOGLE_CLOUD_REGION" \
+  --to-latest


### PR DESCRIPTION
## Summary\n- promote the short board score validation fix from staging to main\n- include the Cloud Run deploy script update that restores traffic to LATEST after deploy\n- include the local Bundler cache ignore change\n\n## Why\n- production is still serving code from main commit 1df4ef5, which does not include the 1-0 / 