### PR TITLE
Fix participant deletion and normalize Gemfile.lock platforms

### DIFF
--- a/apps/ledger/Gemfile.lock
+++ b/apps/ledger/Gemfile.lock
@@ -163,6 +163,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.1-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.19.1-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.19.1-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.1-x86_64-linux-gnu)
@@ -173,6 +175,7 @@ GEM
     pg (1.6.3-aarch64-linux)
     pg (1.6.3-aarch64-linux-musl)
     pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x64-mingw-ucrt)
     pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
     pg (1.6.3-x86_64-linux-musl)
@@ -265,6 +268,8 @@ GEM
       railties (>= 7.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2026.1)
+      tzinfo (>= 1.0.0)
     uri (1.1.1)
     useragent (0.16.11)
     web-console (4.3.0)
@@ -285,6 +290,7 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin
+  x64-mingw-ucrt
   x86_64-darwin
   x86_64-linux
   x86_64-linux-gnu

--- a/apps/ledger/app/models/participant.rb
+++ b/apps/ledger/app/models/participant.rb
@@ -4,6 +4,7 @@ class Participant < ApplicationRecord
   belongs_to :league
   belongs_to :team
 
+  has_many :match_lineup_members, dependent: :destroy
   has_many :home_board_results, class_name: "BoardResult", foreign_key: :home_participant_id, dependent: :nullify
   has_many :away_board_results, class_name: "BoardResult", foreign_key: :away_participant_id, dependent: :nullify
 

--- a/apps/ledger/test/integration/regular_season_operations_flow_test.rb
+++ b/apps/ledger/test/integration/regular_season_operations_flow_test.rb
@@ -714,6 +714,49 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
     assert_redirected_to leagues_path(locale: :ja)
   end
 
+  test "organizer can delete a participant that is still referenced by a lineup" do
+    login_as!(@organizer_account, password: @password)
+
+    league = @organizer_account.leagues.create!(
+      name: "Lineup Delete League",
+      status: "active",
+      roster_min_members: 4,
+      roster_max_members: 8,
+      lineup_size: 3,
+      substitute_size: 1
+    )
+    phase = league.phases.create!(name: "Week 1", stage_asset: regular_stage_asset, position: 1)
+    week = phase.weeks.create!(league:, number: 1, position: 1)
+    home_team = create_team_record_with_members!(league:, name: "Lineup Home")
+    away_team = create_team_record_with_members!(league:, name: "Lineup Away")
+    participant = home_team.participants.order(:position).first
+    match = week.matches.create!(
+      league:,
+      phase:,
+      home_team:,
+      away_team:,
+      scheduled_on: Date.new(2026, 4, 14),
+      scheduled_time: Time.zone.parse("20:00"),
+      status: "scheduled"
+    )
+    match.match_lineup_members.create!(
+      team: home_team,
+      participant:,
+      side: "home",
+      role: "main",
+      slot_number: 1
+    )
+
+    assert_difference("Participant.count", -1) do
+      assert_difference("MatchLineupMember.count", -1) do
+        delete league_team_participant_path(locale: :ja, league_id: league, team_id: home_team, id: participant)
+      end
+    end
+
+    assert_redirected_to league_team_path(locale: :ja, league_id: league, id: home_team)
+    assert_nil match.reload.match_lineup_members.find_by(participant_id: participant.id)
+  end
+
   test "organizer can create participants with member_id and role and see them on team details" do
     login_as!(@organizer_account, password: @password)
 


### PR DESCRIPTION
## Summary
- fix participant deletion when the member is still referenced by match lineup records
- add a regression test covering deletion of lineup-referenced participants
- normalize `Gemfile.lock` platforms so Windows keeps the shared multi-platform lockfile intact

## Root cause
Deleting a team member could fail with a foreign key violation because `match_lineup_members` still referenced the participant record.

## Validation
- `bundle exec rails test test/integration/regular_season_operations_flow_test.rb`
- `bundle platform`