### PR TITLE
Fix stale result card test expectations

### DIFF
--- a/apps/ledger/test/services/match_exports/result_card_renderer_test.rb
+++ b/apps/ledger/test/services/match_exports/result_card_renderer_test.rb
@@ -47,8 +47,8 @@ class MatchExports::ResultCardRendererTest < ActiveSupport::TestCase
     round_one_html = renderer.send(:round_result_html, match.rounds.find_by!(number: 1))
     footer_html = renderer.send(:footer_html)
 
-    assert_includes round_one_html, '<span class="win">W</span>'
-    assert_includes round_one_html, '<span class="lose">L</span>'
+    assert_includes round_one_html, '<span class="round-result__label--win">W</span>'
+    assert_includes round_one_html, '<span class="round-result__label--lose">L</span>'
     assert_includes footer_html, '<div class="footer-score">2 - 0</div>'
   end
 


### PR DESCRIPTION
## What changed
- updated `result_card_renderer_test.rb` to match the current `ResultCardRenderer` CSS class names for win/lose labels
- kept the existing footer expectation unchanged because it already matches the renderer output

## Why
- the renderer has already been emitting `round-result__label--win` / `round-result__label--lose`
- the test was still asserting the old `win` / `lose` classes, so it was failing for a stale expectation rather than a behavior regression

## Impact
- restores alignment between the renderer implementation and its regression test
- does not change application behavior, only the test expectation

## Validation
- `bundle exec ruby -Itest test/services/match_exports/result_card_renderer_test.rb` (blocked locally: PostgreSQL connection refused on `127.0.0.1:5433`)
- diff inspection confirms a two-line expectation-only change
