### PR TITLE
docs: duel-log-api VPS 移行 + shadova エントリ削除

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,4 @@ docker-compose.override.yml
 .devhive/
 .devhive.yaml
 .serena/
-CLAUDE.md
 .claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# Katorin2
+
+## Plane (Issue 管理)
+
+- Plane project: `codenica/KAT` — https://plane.codenica.dev/codenica/projects/687d81ce-9021-4943-ad81-c2f6ef1fc540/issues/
+- Issue 起票は Plane で `KAT-NN` として行う (GitHub Issues / Forgejo Issues は使わない)
+- commit msg は `KAT-12 fix login error` のように Issue ID を先頭に書いて連携する
+- 状況確認は `plane issues KAT` または Web UI

--- a/docs/service-db-users.md
+++ b/docs/service-db-users.md
@@ -15,10 +15,9 @@ service ごとに DB ログインユーザーを分離して運用する。 kato
 |---|---|---|---|
 | `katorin2` (codenica-vps docker, production) | codenica-vps Postgres `katorin2` | `katorin2_prod_app` | `/opt/katorin2/secrets.enc.env` (sops/age) |
 | `katorin2-staging` (codenica-vps docker) | codenica-vps Postgres `katorin2_staging` | `katorin2_staging_app` | `/opt/katorin2-staging/secrets.enc.env` (sops/age) |
-| `duel-log-api` (Cloud Run, production) | Cloud SQL `duellog` | `duel_log_app` | `duel-log-database-url` (VPS 移行予定) |
+| `duel-log-api` (codenica-vps docker, production) | codenica-vps Postgres `duellog` | `duel_log_app` | `/opt/duel-log-api/secrets.enc.env` (sops/age) |
 | `duel-log-api-staging` (codenica-vps docker) | codenica-vps Postgres `duellog_staging` | `duel_log_staging_app` | `/opt/duel-log-api-staging/secrets.enc.env` (sops/age) |
 | `konbu` | Cloud SQL `konbu` | `konbu_app` | `konbu-database-url` (VPS 移行対象外、 課金導線あり) |
-| `shadova-log` | Cloud SQL `shadova` | `shadova_log_app` | `shadova-log-db-password` + `DB_USERNAME` |
 
 補足:
 


### PR DESCRIPTION
## Summary
- duel-log-api 本番が codenica-vps に移行完了したため service-db-users.md を更新
- 廃止済 shadova project のエントリを削除 (Secret Manager の `shadova-log-db-password` も同時に GCP 側で削除済)

## Test plan
- [x] docs only