### PR TITLE
KAT-1 Fix Ferrum browser flags via browser_options

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,4 +5,4 @@
 - Plane project: `codenica/KAT` — https://plane.codenica.dev/codenica/projects/687d81ce-9021-4943-ad81-c2f6ef1fc540/issues/
 - Issue 起票は Plane で `KAT-NN` として行う (GitHub Issues / Forgejo Issues は使わない)
 - commit msg は `KAT-12 fix login error` のように Issue ID を先頭に書いて連携する
-- 状況確認は `plane issues KAT` または Web UI
+- 状況確認は Web UI、 または Claude code セッション内の plane MCP tool (`mcp__plane__list_work_items` 等)

--- a/apps/ledger/app/services/match_exports/result_card_renderer.rb
+++ b/apps/ledger/app/services/match_exports/result_card_renderer.rb
@@ -27,7 +27,12 @@ module MatchExports
         browser_path: ENV["CHROMIUM_PATH"],
         window_size: [WIDTH, MIN_HEIGHT],
         timeout: BROWSER_TIMEOUT,
-        args: ["--no-sandbox", "--disable-gpu"]
+        process_timeout: BROWSER_TIMEOUT,
+        browser_options: {
+          "no-sandbox" => nil,
+          "disable-gpu" => nil,
+          "disable-dev-shm-usage" => nil
+        }
       )
       begin
         page = browser.create_page

--- a/apps/ledger/app/services/standings_exports/table_renderer.rb
+++ b/apps/ledger/app/services/standings_exports/table_renderer.rb
@@ -22,7 +22,12 @@ module StandingsExports
         browser_path: ENV["CHROMIUM_PATH"],
         window_size: [1024, 800],
         timeout: BROWSER_TIMEOUT,
-        args: ["--no-sandbox", "--disable-gpu"]
+        process_timeout: BROWSER_TIMEOUT,
+        browser_options: {
+          "no-sandbox" => nil,
+          "disable-gpu" => nil,
+          "disable-dev-shm-usage" => nil
+        }
       )
       begin
         page = browser.create_page


### PR DESCRIPTION
## Summary
- 本番 (codenica-vps) でスコアシート画像生成が `Ferrum::ProcessTimeoutError` で常時失敗していた不具合を修正
- `Ferrum::Browser.new(args: [...])` は Ferrum 0.17 では無効なキー (正しくは `browser_options:` Hash) のため `--no-sandbox` などが Chromium に一切渡っておらず、 通常 Docker (Cloud Run の gVisor と違い) で sandbox 初期化失敗していた
- `MatchExports::ResultCardRenderer` と `StandingsExports::TableRenderer` の 2 箇所を修正、 Docker 標準 `/dev/shm` 64MB 対策で `--disable-dev-shm-usage` を追加、 `process_timeout` を明示

## Issue
KAT-1: https://plane.codenica.dev/codenica/projects/687d81ce-9021-4943-ad81-c2f6ef1fc540/issues/

## 緊急対応の状況
- 2026-05-16 22:30 JST 頃に VPS 本番コンテナに `docker cp` + `docker restart katorin2` で hot-patch 適用済み (`rails runner` で PNG 生成成功を確認、 253KB の PNG が `89 50 4e 47` magic 付きで出力された)
- このマージで CI/CD が走り正規 image にも修正が焼き込まれるため、 次回 deploy 以降は hot-patch が消えても問題ない

## Test plan
- [x] CI build が green であること
- [x] deploy 後、 `/up` health check が通ること
- [x] 本番で実マッチに対して `/matches/:id/result_card_export/download` を踏んで PNG が DL できることを確認
- [ ] `public/generated/match_exports/*.png` がコンテナ内に再生成されること
- [ ] 順位表 (`/leagues/:id/phases/:id/standings/download`) も PNG が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)