### PR TITLE
KAT-15 docs: main branch protection の admin bypass 不可と CI 必須化を反映

### DIFF
--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -46,8 +46,9 @@ GitHub 側:
   - direct push 可
   - PR 任意
 - `main`
-  - direct push 禁止
+  - direct push 禁止 (admin も bypass 不可、 `enforce_admins=true`)
   - PR 経由のみ
+  - CI (`test` job) 緑が merge 必須
 
 deploy 対応:
 


### PR DESCRIPTION
## Summary

KAT-15 で適用した main branch protection の変更点を `docs/git-workflow.md` に反映する。 振る舞いは変えない (docs 修正のみ)。

GitHub 側設定変更 (= 本 PR とは別途実施済み):

- `enforce_admins=true` (= admin も direct push bypass 不可)
- `required_status_checks.contexts: ["test"]` (= CI test job 緑が merge 必須)
- 既存設定 (`required_linear_history`, `required_pull_request_reviews`, `allow_force_pushes=false`, `allow_deletions=false`) は維持

## Test plan

- [ ] PR 上で CI (`test`) が緑になる
- [ ] merge 後、 `docs/git-workflow.md` の main 行に `enforce_admins=true` と `CI 緑必須` が記載されている
- [ ] (動作確認は不要 — branch protection 設定自体は GitHub 側で既に適用済み)