### PR TITLE
KAT-18 fix: 結果入力の lineup 初期値反映を R1 限定にする

### DIFF
--- a/apps/ledger/app/controllers/match_result_entries_controller.rb
+++ b/apps/ledger/app/controllers/match_result_entries_controller.rb
@@ -53,7 +53,7 @@ class MatchResultEntriesController < ApplicationController
       round = @match.rounds.find { |existing_round| existing_round.number == round_number } || Round.new(number: round_number, result_status: "partial")
       boards = (1..3).map do |board_number|
         board = round.board_results.find { |existing_board| existing_board.board_number == board_number } || BoardResult.new(board_number: board_number, result_status: "partial")
-        apply_lineup_defaults!(board, lineup_defaults[board_number])
+        apply_lineup_defaults!(board, lineup_defaults[board_number]) if round_number == 1
         board
       end
 

--- a/apps/ledger/test/integration/regular_season_operations_flow_test.rb
+++ b/apps/ledger/test/integration/regular_season_operations_flow_test.rb
@@ -141,6 +141,24 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
         "expected away board ##{board_number} to default to lineup main participant"
       )
     end
+    [2, 3].each do |round_number|
+      home_main.each_with_index do |participant, index|
+        board_number = index + 1
+        refute_match(
+          %r{<select [^>]*name="result_entry\[rounds\]\[#{round_number}\]\[boards\]\[#{board_number}\]\[home_participant_id\]"[^>]*>.*?<option selected="selected" value="#{participant.id}">}m,
+          response.body,
+          "round #{round_number} home board ##{board_number} must not default to lineup main"
+        )
+      end
+      away_main.each_with_index do |participant, index|
+        board_number = index + 1
+        refute_match(
+          %r{<select [^>]*name="result_entry\[rounds\]\[#{round_number}\]\[boards\]\[#{board_number}\]\[away_participant_id\]"[^>]*>.*?<option selected="selected" value="#{participant.id}">}m,
+          response.body,
+          "round #{round_number} away board ##{board_number} must not default to lineup main"
+        )
+      end
+    end
 
     assert_enqueued_with(job: MatchExports::GenerateResultCardJob, args: [match.id]) do
       patch match_result_entry_path(locale: :ja, match_id: match), params: {


### PR DESCRIPTION
## Summary

- KAT-12 (`1acdb58`) で導入した結果入力初回値の lineup 反映が、 controller で `round_number` を見ずに R1/R2/R3 全 round に同じ defaults を適用していた。
- 「ラウンドごとにオーダー変更可」 の WMGP 運用に反する挙動だったため、 `apply_lineup_defaults!` 呼び出しを `round_number == 1` ガードで限定。
- 統合テストに R2/R3 で defaults が適用されないことの assertion を追加。

## Test plan

- [x] `bin/rails test test/integration/regular_season_operations_flow_test.rb` 緑 (21 runs / 589 assertions)
- [x] `bin/rails test` 緑 (56 runs / 864 assertions)
- [ ] staging で結果入力画面を開き、 R1 のみ lineup main が初期選択、 R2/R3 は空であることを目視確認

Closes KAT-18