### PR TITLE
KAT-20 enhance: 相手 team 辞退時は選手未入力でも結果確定できるようにする

### DIFF
--- a/apps/ledger/app/services/match_results/recorder.rb
+++ b/apps/ledger/app/services/match_results/recorder.rb
@@ -128,11 +128,15 @@ module MatchResults
     end
 
     def board_complete?(home_participant_id, away_participant_id, home_deck_name, away_deck_name, home_game_wins, away_game_wins)
-      home_participant_id.present? &&
-        away_participant_id.present? &&
-        home_deck_name.present? &&
-        away_deck_name.present? &&
+      side_inputs_complete?(match.home_team, home_participant_id, home_deck_name) &&
+        side_inputs_complete?(match.away_team, away_participant_id, away_deck_name) &&
         BoardResult.valid_confirmed_score?(home_game_wins, away_game_wins)
+    end
+
+    def side_inputs_complete?(team, participant_id, deck_name)
+      return true if team&.status == "withdrawn"
+
+      participant_id.present? && deck_name.present?
     end
 
     def integer_or_nil(value)

--- a/apps/ledger/app/views/match_result_entries/edit.html.erb
+++ b/apps/ledger/app/views/match_result_entries/edit.html.erb
@@ -36,6 +36,10 @@
 
 <section class="panel result-entry-form-panel">
   <%= form_with url: match_result_entry_path(match_id: @match), method: :patch, scope: :result_entry, class: "stack result-entry-form" do |form| %>
+    <% withdrawn_team_labels = [@match.home_team, @match.away_team].compact.select { |team| team.status == "withdrawn" }.map { |team| t("matches.result_entry.withdrawn_team_label", team: team.display_name) } %>
+    <% if withdrawn_team_labels.any? %>
+      <p class="muted"><%= t("matches.result_entry.withdrawn_note", teams: withdrawn_team_labels.join(" / ")) %></p>
+    <% end %>
     <% @round_entries.each do |entry| %>
       <% round = entry[:round] %>
       <article class="panel panel--nested">

--- a/apps/ledger/config/locales/en.yml
+++ b/apps/ledger/config/locales/en.yml
@@ -533,6 +533,8 @@ en:
       no_winner: Unselected
       board_summary: "Board %{number}: %{home} vs %{away} / Winner %{winner}"
       board_summary_with_score: "Board %{number}: %{home} (%{home_deck}) %{home_score} - %{away_score} (%{away_deck}) %{away}"
+      withdrawn_note: "This match involves a withdrawn team. Member and deck for the withdrawn side (%{teams}) may be left blank to confirm the result."
+      withdrawn_team_label: "%{team} (withdrawn)"
     form:
       home_team: Home team
       away_team: Away team

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -533,6 +533,8 @@ ja:
       no_winner: 未選択
       board_summary: "卓 %{number}: %{home} 対 %{away} / 勝者 %{winner}"
       board_summary_with_score: "卓 %{number}: %{home} (%{home_deck}) %{home_score} - %{away_score} (%{away_deck}) %{away}"
+      withdrawn_note: "辞退チームを含む試合です。辞退側 (%{teams}) の選手とデッキは未入力のままで結果確定できます。"
+      withdrawn_team_label: "%{team} (辞退)"
     form:
       home_team: ホームチーム
       away_team: アウェイチーム

--- a/apps/ledger/test/integration/regular_season_operations_flow_test.rb
+++ b/apps/ledger/test/integration/regular_season_operations_flow_test.rb
@@ -308,6 +308,65 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
     assert_equal [team_a, team_b, nil], match.rounds.order(:number).map(&:winner_team)
   end
 
+  test "organizer can confirm a regular season match when the opponent team is withdrawn" do
+    login_as!(@organizer_account, password: @password)
+
+    league = @organizer_account.leagues.create!(
+      name: "Withdrawn League",
+      status: "draft",
+      roster_min_members: 4,
+      roster_max_members: 8,
+      lineup_size: 3,
+      substitute_size: 1
+    )
+    phase = league.phases.create!(name: "予選 1", stage_asset: regular_stage_asset, position: 1)
+    block = phase.blocks.create!(league:, name: "Block A", position: 1)
+    week = phase.weeks.create!(league:, number: 1, position: 1)
+    team_a = create_team_record_with_members!(league:, name: "Active Team A")
+    team_b = create_team_record_with_members!(league:, name: "Withdrawn Team B")
+    team_b.update!(status: "withdrawn")
+    match = week.matches.create!(
+      league: league,
+      phase: phase,
+      block: block,
+      home_team: team_a,
+      away_team: team_b,
+      scheduled_on: Date.new(2026, 4, 12),
+      scheduled_time: Time.zone.parse("20:00"),
+      status: "scheduled"
+    )
+
+    get edit_match_result_entry_path(locale: :ja, match_id: match)
+    assert_response :success
+    assert_includes response.body, "辞退チームを含む試合です"
+
+    home_main = team_a.participants.order(:position).first(3)
+    patch match_result_entry_path(locale: :ja, match_id: match), params: {
+      result_entry: {
+        rounds: {
+          "1" => withdrawn_round_payload(home_main, suffix: "W1"),
+          "2" => withdrawn_round_payload(home_main, suffix: "W2")
+        }
+      }
+    }
+    assert_redirected_to edit_match_result_entry_path(locale: :ja, match_id: match)
+
+    match.reload
+    assert_equal "confirmed", match.status
+    assert_equal team_a, match.match_result.winner_team
+    assert_equal [2, 0], [match.match_result.home_round_wins, match.match_result.away_round_wins]
+    rounds = match.rounds.order(:number)
+    assert_equal 2, rounds.count
+    assert_equal [true, true], rounds.map(&:confirmed?)
+    rounds.each do |round|
+      round.board_results.each do |board|
+        assert_nil board.away_participant_id, "withdrawn side participant must remain nil"
+        assert_nil board.away_deck_name, "withdrawn side deck must remain nil"
+        assert_equal "confirmed", board.result_status
+      end
+    end
+  end
+
   test "organizer can save 1-0 and 0-1 board scores" do
     login_as!(@organizer_account, password: @password)
 
@@ -1198,6 +1257,25 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
       "away_deck_name" => away_deck,
       "home_game_wins" => score[0],
       "away_game_wins" => score[1]
+    }
+  end
+
+  def withdrawn_round_payload(home_main, suffix:)
+    {
+      "boards" => {
+        "1" => withdrawn_board_payload(home_main[0], "#{suffix} Deck A1"),
+        "2" => withdrawn_board_payload(home_main[1], "#{suffix} Deck A2"),
+        "3" => withdrawn_board_payload(home_main[2], "#{suffix} Deck A3")
+      }
+    }
+  end
+
+  def withdrawn_board_payload(home_participant, home_deck)
+    {
+      "home_participant_id" => home_participant.id,
+      "home_deck_name" => home_deck,
+      "home_game_wins" => 2,
+      "away_game_wins" => 0
     }
   end
 


### PR DESCRIPTION
## Summary

- `MatchResults::Recorder#board_complete?` の participant_id / deck_name 必須判定を side ごとに分割し、 該当 side の `team.status == "withdrawn"` の場合は要求しない (= 不戦勝扱い)
- 結果入力画面に辞退チームを含む試合である旨の注記を表示
- score (game_wins) は引き続き必須 (= 試合自体の成立確認)

## Why

運営者要望 (本日): 「相手チームが DQ したときに選手名入れなくても結果確定できるようにしてくれるとたすかる」。 これまでは DQ 側にもダミー選手を立てる必要があり、 運営の手間 + 実在しない出場記録がデータに残る問題があった。

## Test plan

- [x] `bin/rails test test/integration/regular_season_operations_flow_test.rb` 緑 (新規 case: 相手 withdrawn で 2 ラウンド先取で confirmed、 withdrawn 側の participant_id / deck_name が nil のまま保存される)
- [x] `bin/rails test` 全体緑 (60 runs, 909 assertions, 0 failures)
- [ ] staging で実際に team status を withdrawn に変えた match で結果入力動作確認

## 関連

- Plane Issue: KAT-20
- 触らない範囲: 既存の (非 DQ × 非 DQ) 試合の挙動、 順位計算ロジック (= `Standings::Calculator`)