### PR TITLE
docs: HANDOFF.md セクションを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,3 +4,7 @@
 
 - identifier: `KAT` — https://plane.codenica.dev/codenica/projects/63a43153-13a7-409a-ba5a-bd19d93c1b68/issues/
 - 共通運用 (Issue 起票 / commit msg / 状況確認) は global `~/.claude/CLAUDE.md` 「プロジェクト管理 (Plane)」 参照
+
+## HANDOFF.md
+
+- 構造 / max 行数 / 「中断 context 復元用」 専用ルールは global `~/.claude/CLAUDE.md` 「プロジェクト管理 (Plane) と セッション引き継ぎ (HANDOFF.md) の役割分担」 → 「HANDOFF.md (短期 / 作業単位の記憶)」 参照


### PR DESCRIPTION
## Summary

global CLAUDE.md の「HANDOFF.md (短期 / 作業単位の記憶)」 統一仕様に揃えて pointer section を追加。 構造 / max 行数 / 「中断 context 復元用」 専用ルールは global を参照する形。

## Test plan

- [ ] docs only、 機能変更なし
- [ ] CLAUDE.md の他 section に影響なし