### PR TITLE
KAT-21 enhance: 結果入力画面に home/away チーム管理画面への導線を追加

### DIFF
--- a/apps/ledger/app/controllers/teams_controller.rb
+++ b/apps/ledger/app/controllers/teams_controller.rb
@@ -8,6 +8,7 @@ class TeamsController < ApplicationController
   end
 
   def show
+    @return_to = safe_return_to(params[:return_to])
     load_team_detail_state
   end
 
@@ -62,5 +63,13 @@ class TeamsController < ApplicationController
 
   def team_params
     params.require(:team).permit(:display_name, :status, :notes)
+  end
+
+  def safe_return_to(value)
+    return nil if value.blank?
+    return nil unless value.start_with?("/")
+    return nil if value.start_with?("//")
+
+    value
   end
 end

--- a/apps/ledger/app/views/match_result_entries/edit.html.erb
+++ b/apps/ledger/app/views/match_result_entries/edit.html.erb
@@ -17,6 +17,12 @@
     <p class="muted"><%= match_title_text(@match) %></p>
   </div>
   <div class="page-actions">
+    <% if @match.home_team.present? %>
+      <%= link_to t("matches.result_entry.manage_team", team: @match.home_team.display_name), league_team_path(league_id: @match.league, id: @match.home_team, return_to: edit_match_result_entry_path(match_id: @match)), class: "button" %>
+    <% end %>
+    <% if @match.away_team.present? %>
+      <%= link_to t("matches.result_entry.manage_team", team: @match.away_team.display_name), league_team_path(league_id: @match.league, id: @match.away_team, return_to: edit_match_result_entry_path(match_id: @match)), class: "button" %>
+    <% end %>
     <%= link_to t("actions.back"), match_path(id: @match), class: "button" %>
     <%= link_to t("actions.edit"), edit_match_path(id: @match), class: "button" %>
   </div>

--- a/apps/ledger/app/views/teams/show.html.erb
+++ b/apps/ledger/app/views/teams/show.html.erb
@@ -14,6 +14,9 @@
     <p class="muted"><%= [translated_enum("enums.team.status", @team.status), @team.block&.name, t("labels.participants_count", count: @participants.size)].compact.join(" / ") %></p>
   </div>
   <div class="page-actions">
+    <% if @return_to.present? %>
+      <%= link_to t("teams.back_to_result_entry"), @return_to, class: "button button--primary" %>
+    <% end %>
     <%= link_to t("actions.back"), league_teams_path(league_id: @league), class: "button" %>
     <% if can_manage? %>
       <%= link_to t("actions.edit"), edit_league_team_path(league_id: @league, id: @team), class: "button" %>

--- a/apps/ledger/config/locales/en.yml
+++ b/apps/ledger/config/locales/en.yml
@@ -256,6 +256,7 @@ en:
       notes: Notes
     delete_confirm: Delete this team?
     delete_hint: Only teams that are not used in matches can be deleted.
+    back_to_result_entry: Back to result entry
   participants:
     eyebrow: Members
     title_new: "Add member to %{team}"
@@ -535,6 +536,7 @@ en:
       board_summary_with_score: "Board %{number}: %{home} (%{home_deck}) %{home_score} - %{away_score} (%{away_deck}) %{away}"
       withdrawn_note: "This match involves a withdrawn team. Member and deck for the withdrawn side (%{teams}) may be left blank to confirm the result."
       withdrawn_team_label: "%{team} (withdrawn)"
+      manage_team: "Manage %{team}"
     form:
       home_team: Home team
       away_team: Away team

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -256,6 +256,7 @@ ja:
       notes: メモ
     delete_confirm: このチームを削除します。よろしいですか？
     delete_hint: 対戦で未使用のチームだけ削除できます。
+    back_to_result_entry: 結果入力に戻る
   participants:
     eyebrow: メンバー
     title_new: "%{team} にメンバー追加"
@@ -535,6 +536,7 @@ ja:
       board_summary_with_score: "卓 %{number}: %{home} (%{home_deck}) %{home_score} - %{away_score} (%{away_deck}) %{away}"
       withdrawn_note: "辞退チームを含む試合です。辞退側 (%{teams}) の選手とデッキは未入力のままで結果確定できます。"
       withdrawn_team_label: "%{team} (辞退)"
+      manage_team: "%{team} を管理"
     form:
       home_team: ホームチーム
       away_team: アウェイチーム

--- a/apps/ledger/test/integration/regular_season_operations_flow_test.rb
+++ b/apps/ledger/test/integration/regular_season_operations_flow_test.rb
@@ -873,6 +873,50 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
     assert_redirected_to league_team_path(locale: :ja, league_id: league, id: home_team)
   end
 
+  test "result entry shows manage team links that return the user to result entry" do
+    login_as!(@organizer_account, password: @password)
+
+    league = @organizer_account.leagues.create!(
+      name: "Result Entry Manage Team League",
+      status: "active",
+      roster_min_members: 4,
+      roster_max_members: 8,
+      lineup_size: 3,
+      substitute_size: 1
+    )
+    phase = league.phases.create!(name: "予選 1", stage_asset: regular_stage_asset, position: 1)
+    week = phase.weeks.create!(league:, number: 1, position: 1)
+    home_team = create_team_record_with_members!(league:, name: "Result Entry Home")
+    away_team = create_team_record_with_members!(league:, name: "Result Entry Away")
+    match = week.matches.create!(
+      league:,
+      phase:,
+      home_team:,
+      away_team:,
+      scheduled_on: Date.new(2026, 4, 16),
+      scheduled_time: Time.zone.parse("20:00"),
+      status: "scheduled"
+    )
+
+    get edit_match_result_entry_path(locale: :ja, match_id: match)
+    assert_response :success
+    expected_return_to = edit_match_result_entry_path(locale: :ja, match_id: match)
+    encoded_return_to = ERB::Util.url_encode(expected_return_to)
+    assert_includes response.body, league_team_path(locale: :ja, league_id: league, id: home_team, return_to: expected_return_to)
+    assert_includes response.body, league_team_path(locale: :ja, league_id: league, id: away_team, return_to: expected_return_to)
+    assert_includes response.body, "を管理"
+    assert_match(/return_to=#{Regexp.escape(encoded_return_to)}/, response.body)
+
+    get league_team_path(locale: :ja, league_id: league, id: home_team, return_to: expected_return_to)
+    assert_response :success
+    assert_includes response.body, "結果入力に戻る"
+    assert_includes response.body, %(href="#{expected_return_to}")
+
+    get league_team_path(locale: :ja, league_id: league, id: home_team, return_to: "//evil.example.com/result-entries")
+    assert_response :success
+    refute_includes response.body, "結果入力に戻る"
+  end
+
   test "organizer can delete a participant that is still referenced by a lineup" do
     login_as!(@organizer_account, password: @password)
 


### PR DESCRIPTION
## Summary
- 結果入力画面 (`match_result_entries/edit`) の page-actions に home / away それぞれの 「<team名> を管理」 ボタンを追加。 該当 team の `teams/show` に `return_to` 付きで遷移する
- `teams_controller#show` が `return_to` を受け取り、 `safe_return_to` で `/` 始まり (= 同一オリジン相対パス) のみ許容。 `//` 始まりや http(s):// は弾く
- `teams/show` の page-actions に `return_to` 付き時のみ 「結果入力に戻る」 リンクを表示
- locales (ja / en) に `matches.result_entry.manage_team` / `teams.back_to_result_entry` を追加
- KAT-13 (オーダー登録画面の選手追加導線) と同型パターン、 `safe_return_to` は participants_controller のものと同じロジックを teams_controller 側に持たせる (= 2 controller 重複は許容範囲、 3 つ目が出たら共通 concern に切り出す判断)

## Plane
- KAT-21 (= 結果入力画面に home/away のチーム管理画面へ飛べる導線を追加する)

## Test plan
- [x] `bin/rails test test/integration/regular_season_operations_flow_test.rb` 緑 (23 runs)
- [x] `bin/rails test` 緑 (61 runs / 934 assertions / 0 failures)
- [x] 新規 test: 結果入力画面で home/away link + return_to の URL が出ること、 teams/show を return_to 付きで開くと「結果入力に戻る」 が出ること、 `//evil.example.com/...` 形式の return_to は弾かれて戻りボタンが出ないこと