### PR TITLE
KAT-22 feat: week 画面にデッキ別集計と CSV ダウンロードを追加

### DIFF
--- a/apps/ledger/app/controllers/weeks_controller.rb
+++ b/apps/ledger/app/controllers/weeks_controller.rb
@@ -1,7 +1,7 @@
 class WeeksController < ApplicationController
   before_action :set_phase
   before_action :ensure_regular_phase
-  before_action :set_week, only: %i[show edit update destroy]
+  before_action :set_week, only: %i[show edit update destroy deck_usage_csv]
   before_action :admin_or_above!, only: %i[new create edit update destroy]
 
   def show
@@ -11,6 +11,14 @@ class WeeksController < ApplicationController
     if grouped.key?(nil)
       @block_sections << [nil, grouped.delete(nil)]
     end
+    @deck_usage_summary = Decks::UsageSummary.new(@week)
+  end
+
+  def deck_usage_csv
+    csv = Decks::UsageSummary.new(@week).to_csv
+    send_data csv,
+      filename: "deck-usage-#{@phase.id}-week-#{@week.number}.csv",
+      type: "text/csv; charset=utf-8"
   end
 
   def new

--- a/apps/ledger/app/services/decks/usage_summary.rb
+++ b/apps/ledger/app/services/decks/usage_summary.rb
@@ -1,0 +1,89 @@
+require "csv"
+
+module Decks
+  class UsageSummary
+    Entry = Struct.new(:deck_name, :user_count, :wins, :losses, keyword_init: true) do
+      def total
+        wins + losses
+      end
+
+      def win_rate
+        return nil if total.zero?
+
+        wins.fdiv(total)
+      end
+    end
+
+    CSV_HEADERS = %i[deck_name user_count wins losses win_rate].freeze
+
+    def initialize(week)
+      @week = week
+    end
+
+    def entries
+      @entries ||= build_entries
+    end
+
+    def empty?
+      entries.empty?
+    end
+
+    def to_csv
+      ::CSV.generate do |csv|
+        csv << CSV_HEADERS.map { |key| I18n.t("decks.usage.csv.#{key}") }
+        entries.each do |entry|
+          csv << [
+            entry.deck_name,
+            entry.user_count,
+            entry.wins,
+            entry.losses,
+            entry.win_rate.nil? ? "" : format("%.3f", entry.win_rate)
+          ]
+        end
+      end
+    end
+
+    private
+
+    attr_reader :week
+
+    def build_entries
+      grouped = Hash.new { |hash, key| hash[key] = [] }
+
+      board_results.find_each do |board|
+        side_record(grouped, board.home_deck_name, board.home_participant_id, side_result(board, "home"))
+        side_record(grouped, board.away_deck_name, board.away_participant_id, side_result(board, "away"))
+      end
+
+      grouped.map { |deck_name, sides| build_entry(deck_name, sides) }
+             .sort_by { |entry| [-entry.user_count, -entry.wins, entry.deck_name] }
+    end
+
+    def build_entry(deck_name, sides)
+      Entry.new(
+        deck_name: deck_name,
+        user_count: sides.map { |side| side[:participant_id] }.compact.uniq.size,
+        wins: sides.count { |side| side[:result] == :win },
+        losses: sides.count { |side| side[:result] == :loss }
+      )
+    end
+
+    def board_results
+      BoardResult
+        .joins(round: :match)
+        .where(matches: { week_id: week.id })
+    end
+
+    def side_record(hash, deck_name, participant_id, result)
+      return if deck_name.blank?
+
+      hash[deck_name] << { participant_id: participant_id, result: result }
+    end
+
+    def side_result(board, side)
+      return :draw if board.winner_side.blank?
+
+      board.winner_side == side ? :win : :loss
+    end
+  end
+end

--- a/apps/ledger/app/views/weeks/show.html.erb
+++ b/apps/ledger/app/views/weeks/show.html.erb
@@ -22,6 +22,49 @@
 </section>
 
 <section class="stack">
+  <article class="panel">
+    <div class="panel-header">
+      <div>
+        <h2><%= t("decks.usage.title") %></h2>
+        <p class="muted"><%= t("decks.usage.scope_note") %></p>
+      </div>
+      <% if @deck_usage_summary.entries.any? %>
+        <div class="page-actions">
+          <%= link_to t("decks.usage.download_csv"), deck_usage_csv_phase_week_path(phase_id: @phase, id: @week, format: :csv), class: "button" %>
+        </div>
+      <% end %>
+    </div>
+
+    <% if @deck_usage_summary.entries.any? %>
+      <div class="table-scroll">
+        <table class="standings-table">
+          <thead>
+            <tr>
+              <th><%= t("decks.usage.columns.deck_name") %></th>
+              <th><%= t("decks.usage.columns.user_count") %></th>
+              <th><%= t("decks.usage.columns.wins") %></th>
+              <th><%= t("decks.usage.columns.losses") %></th>
+              <th><%= t("decks.usage.columns.win_rate") %></th>
+            </tr>
+          </thead>
+          <tbody>
+            <% @deck_usage_summary.entries.each do |entry| %>
+              <tr>
+                <td><%= entry.deck_name %></td>
+                <td><%= entry.user_count %></td>
+                <td><%= entry.wins %></td>
+                <td><%= entry.losses %></td>
+                <td><%= entry.win_rate.nil? ? t("decks.usage.win_rate_unavailable") : number_to_percentage(entry.win_rate * 100, precision: 1) %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </div>
+    <% else %>
+      <p class="empty-copy"><%= t("decks.usage.empty") %></p>
+    <% end %>
+  </article>
+
   <% if @matches.any? %>
     <% @block_sections.each do |block, matches| %>
       <article class="panel">

--- a/apps/ledger/config/locales/en.yml
+++ b/apps/ledger/config/locales/en.yml
@@ -757,3 +757,22 @@ en:
       round_board_diff: BRD
       match_game_diff: MGD
       board_wins_total: BWT
+  decks:
+    usage:
+      title: Deck usage summary
+      scope_note: Aggregated decks recorded across matches in this week.
+      empty: No deck usage data for this week yet.
+      download_csv: Download CSV
+      win_rate_unavailable: "-"
+      columns:
+        deck_name: Deck name
+        user_count: Users
+        wins: Wins
+        losses: Losses
+        win_rate: Win rate
+      csv:
+        deck_name: Deck name
+        user_count: Users
+        wins: Wins
+        losses: Losses
+        win_rate: Win rate

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -757,3 +757,22 @@ ja:
       round_board_diff: ラウンド得失点
       match_game_diff: マッチ得失点
       board_wins_total: ラウンド総得点
+  decks:
+    usage:
+      title: デッキ別集計
+      scope_note: この週の対戦で記録されたデッキの集計です。
+      empty: この週の集計対象データがまだありません。
+      download_csv: CSV をダウンロード
+      win_rate_unavailable: "-"
+      columns:
+        deck_name: デッキ名
+        user_count: 使用者数
+        wins: 勝ち
+        losses: 負け
+        win_rate: 勝率
+      csv:
+        deck_name: デッキ名
+        user_count: 使用者数
+        wins: 勝ち
+        losses: 負け
+        win_rate: 勝率

--- a/apps/ledger/config/routes.rb
+++ b/apps/ledger/config/routes.rb
@@ -64,7 +64,11 @@ Rails.application.routes.draw do
           delete :unassign_team
         end
       end
-      resources :weeks, only: %i[show new create edit update destroy]
+      resources :weeks, only: %i[show new create edit update destroy] do
+        member do
+          get :deck_usage_csv
+        end
+      end
     end
 
     resources :weeks, only: [] do

--- a/apps/ledger/test/integration/regular_season_operations_flow_test.rb
+++ b/apps/ledger/test/integration/regular_season_operations_flow_test.rb
@@ -917,6 +917,69 @@ class RegularSeasonOperationsFlowTest < ActionDispatch::IntegrationTest
     refute_includes response.body, "結果入力に戻る"
   end
 
+  test "week show displays deck usage summary and exposes a working csv download" do
+    login_as!(@organizer_account, password: @password)
+
+    league = @organizer_account.leagues.create!(
+      name: "Deck Usage League",
+      status: "active",
+      roster_min_members: 4,
+      roster_max_members: 8,
+      lineup_size: 3,
+      substitute_size: 1
+    )
+    phase = league.phases.create!(name: "予選 1", stage_asset: regular_stage_asset, position: 1)
+    block = phase.blocks.create!(league:, name: "Block A", position: 1)
+    empty_week = phase.weeks.create!(league:, number: 1, position: 1)
+    populated_week = phase.weeks.create!(league:, number: 2, position: 2)
+    home_team = create_team_record_with_members!(league:, name: "Deck Home")
+    away_team = create_team_record_with_members!(league:, name: "Deck Away")
+    match = populated_week.matches.create!(
+      league:,
+      phase:,
+      block:,
+      home_team:,
+      away_team:,
+      scheduled_on: Date.new(2026, 4, 20),
+      scheduled_time: Time.zone.parse("20:00"),
+      status: "scheduled"
+    )
+    round = match.rounds.create!(number: 1, result_status: "confirmed", home_team:, away_team:)
+    round.board_results.create!(
+      board_number: 1,
+      home_participant: home_team.participants.first,
+      away_participant: away_team.participants.first,
+      home_deck_name: "Aggregator Deck",
+      away_deck_name: "Defender Deck",
+      home_game_wins: 2,
+      away_game_wins: 0,
+      winner_side: "home",
+      result_status: "confirmed"
+    )
+
+    get phase_week_path(locale: :ja, phase_id: phase, id: empty_week)
+    assert_response :success
+    assert_includes response.body, "デッキ別集計"
+    assert_includes response.body, "この週の集計対象データがまだありません。"
+    refute_includes response.body, "CSV をダウンロード"
+
+    get phase_week_path(locale: :ja, phase_id: phase, id: populated_week)
+    assert_response :success
+    assert_includes response.body, "デッキ別集計"
+    assert_includes response.body, "Aggregator Deck"
+    assert_includes response.body, "Defender Deck"
+    assert_includes response.body, "CSV をダウンロード"
+    assert_includes response.body, deck_usage_csv_phase_week_path(locale: :ja, phase_id: phase, id: populated_week, format: :csv)
+
+    get deck_usage_csv_phase_week_path(locale: :ja, phase_id: phase, id: populated_week, format: :csv)
+    assert_response :success
+    assert_equal "text/csv", response.media_type
+    assert_includes response.headers["Content-Disposition"], "deck-usage-#{phase.id}-week-#{populated_week.number}.csv"
+    assert_includes response.body, "デッキ名,使用者数,勝ち,負け,勝率"
+    assert_includes response.body, "Aggregator Deck,1,1,0,1.000"
+    assert_includes response.body, "Defender Deck,1,0,1,0.000"
+  end
+
   test "organizer can delete a participant that is still referenced by a lineup" do
     login_as!(@organizer_account, password: @password)
 

--- a/apps/ledger/test/services/decks/usage_summary_test.rb
+++ b/apps/ledger/test/services/decks/usage_summary_test.rb
@@ -1,0 +1,165 @@
+require "test_helper"
+
+class Decks::UsageSummaryTest < ActiveSupport::TestCase
+  setup do
+    @organizer = OrganizerAccount.create!(
+      display_name: "Deck Usage Org",
+      login_id: "deck-usage-org",
+      email: "deck-usage@example.com",
+      password: "password"
+    )
+    @organizer.ensure_default_stage_assets!
+    @league = @organizer.leagues.create!(
+      name: "Deck Usage League",
+      status: "active",
+      roster_min_members: 4,
+      roster_max_members: 8,
+      lineup_size: 3,
+      substitute_size: 1
+    )
+    regular_stage_asset = @organizer.stage_assets.find_by!(format: "round_robin")
+    @phase = @league.phases.create!(name: "予選 1", stage_asset: regular_stage_asset, position: 1)
+    @block = @phase.blocks.create!(league: @league, name: "Block A", position: 1)
+    @week = @phase.weeks.create!(league: @league, number: 1, position: 1)
+  end
+
+  test "returns empty entries when the week has no recorded boards" do
+    summary = Decks::UsageSummary.new(@week)
+
+    assert summary.empty?
+    assert_equal [], summary.entries
+  end
+
+  test "aggregates wins, losses, and unique users per deck across the week" do
+    home_team = create_team!("Home")
+    away_team = create_team!("Away")
+    home_alice = home_team.participants.first
+    home_bob = home_team.participants.second
+    away_carol = away_team.participants.first
+
+    match = create_match!(home_team: home_team, away_team: away_team)
+    round = match.rounds.create!(number: 1, result_status: "confirmed", home_team: home_team, away_team: away_team)
+    round.board_results.create!(board_number: 1, home_participant: home_alice, away_participant: away_carol,
+      home_deck_name: "Deck X", away_deck_name: "Deck Y",
+      home_game_wins: 2, away_game_wins: 0, winner_side: "home", result_status: "confirmed")
+    round.board_results.create!(board_number: 2, home_participant: home_bob, away_participant: away_carol,
+      home_deck_name: "Deck X", away_deck_name: "Deck Y",
+      home_game_wins: 0, away_game_wins: 2, winner_side: "away", result_status: "confirmed")
+
+    entries = Decks::UsageSummary.new(@week).entries
+    deck_x = entries.find { |entry| entry.deck_name == "Deck X" }
+    deck_y = entries.find { |entry| entry.deck_name == "Deck Y" }
+
+    assert_equal 2, deck_x.user_count, "Deck X was played by both home_alice and home_bob"
+    assert_equal 1, deck_x.wins
+    assert_equal 1, deck_x.losses
+    assert_in_delta 0.5, deck_x.win_rate, 0.001
+
+    assert_equal 1, deck_y.user_count, "Deck Y was only played by away_carol"
+    assert_equal 1, deck_y.wins
+    assert_equal 1, deck_y.losses
+  end
+
+  test "sorts entries by user_count desc then wins desc then deck_name asc" do
+    home_team = create_team!("Sort Home")
+    away_team = create_team!("Sort Away")
+    match = create_match!(home_team: home_team, away_team: away_team)
+    round = match.rounds.create!(number: 1, result_status: "confirmed", home_team: home_team, away_team: away_team)
+    round.board_results.create!(board_number: 1, home_participant: home_team.participants.first, away_participant: away_team.participants.first,
+      home_deck_name: "Beta Deck", away_deck_name: "Alpha Deck",
+      home_game_wins: 2, away_game_wins: 0, winner_side: "home", result_status: "confirmed")
+    round.board_results.create!(board_number: 2, home_participant: home_team.participants.second, away_participant: away_team.participants.second,
+      home_deck_name: "Beta Deck", away_deck_name: "Gamma Deck",
+      home_game_wins: 0, away_game_wins: 2, winner_side: "away", result_status: "confirmed")
+    round.board_results.create!(board_number: 3, home_participant: home_team.participants.third, away_participant: away_team.participants.third,
+      home_deck_name: "Alpha Deck", away_deck_name: "Gamma Deck",
+      home_game_wins: 2, away_game_wins: 1, winner_side: "home", result_status: "confirmed")
+
+    entries = Decks::UsageSummary.new(@week).entries
+    assert_equal %w[Alpha\ Deck Beta\ Deck Gamma\ Deck], entries.map(&:deck_name),
+      "Alpha and Beta both have 2 users; Alpha wins more so it sorts first, then Beta, then Gamma with 2 users"
+  end
+
+  test "counts users for draw boards but contributes 0 wins and 0 losses" do
+    home_team = create_team!("Draw Home")
+    away_team = create_team!("Draw Away")
+    match = create_match!(home_team: home_team, away_team: away_team)
+    round = match.rounds.create!(number: 1, result_status: "partial", home_team: home_team, away_team: away_team)
+    round.board_results.create!(board_number: 1, home_participant: home_team.participants.first, away_participant: away_team.participants.first,
+      home_deck_name: "Draw Deck", away_deck_name: "Draw Deck",
+      home_game_wins: 1, away_game_wins: 1, winner_side: nil, result_status: "confirmed")
+
+    entries = Decks::UsageSummary.new(@week).entries
+    draw_deck = entries.find { |entry| entry.deck_name == "Draw Deck" }
+
+    assert_equal 2, draw_deck.user_count
+    assert_equal 0, draw_deck.wins
+    assert_equal 0, draw_deck.losses
+    assert_nil draw_deck.win_rate
+  end
+
+  test "only aggregates boards belonging to the given week" do
+    home_team = create_team!("Scope Home")
+    away_team = create_team!("Scope Away")
+    other_week = @phase.weeks.create!(league: @league, number: 2, position: 2)
+
+    in_week_match = create_match!(home_team: home_team, away_team: away_team)
+    in_week_round = in_week_match.rounds.create!(number: 1, result_status: "confirmed", home_team: home_team, away_team: away_team)
+    in_week_round.board_results.create!(board_number: 1, home_participant: home_team.participants.first, away_participant: away_team.participants.first,
+      home_deck_name: "InWeek Deck", away_deck_name: "Opponent Deck",
+      home_game_wins: 2, away_game_wins: 0, winner_side: "home", result_status: "confirmed")
+
+    other_match = create_match!(home_team: home_team, away_team: away_team, week: other_week)
+    other_round = other_match.rounds.create!(number: 1, result_status: "confirmed", home_team: home_team, away_team: away_team)
+    other_round.board_results.create!(board_number: 1, home_participant: home_team.participants.first, away_participant: away_team.participants.first,
+      home_deck_name: "Other Week Deck", away_deck_name: "Opponent Deck",
+      home_game_wins: 2, away_game_wins: 0, winner_side: "home", result_status: "confirmed")
+
+    entries = Decks::UsageSummary.new(@week).entries
+    deck_names = entries.map(&:deck_name)
+
+    assert_includes deck_names, "InWeek Deck"
+    refute_includes deck_names, "Other Week Deck", "boards from other weeks must not leak in"
+  end
+
+  test "to_csv emits localized header and one row per entry sorted by user_count desc" do
+    home_team = create_team!("CSV Home")
+    away_team = create_team!("CSV Away")
+    match = create_match!(home_team: home_team, away_team: away_team)
+    round = match.rounds.create!(number: 1, result_status: "confirmed", home_team: home_team, away_team: away_team)
+    round.board_results.create!(board_number: 1, home_participant: home_team.participants.first, away_participant: away_team.participants.first,
+      home_deck_name: "CSV Deck", away_deck_name: "CSV Deck",
+      home_game_wins: 2, away_game_wins: 0, winner_side: "home", result_status: "confirmed")
+
+    I18n.with_locale(:ja) do
+      csv = Decks::UsageSummary.new(@week).to_csv
+      lines = csv.lines.map(&:strip)
+
+      assert_equal "デッキ名,使用者数,勝ち,負け,勝率", lines.first
+      assert_equal "CSV Deck,2,1,1,0.500", lines[1]
+    end
+  end
+
+  private
+
+  def create_team!(name)
+    team = @league.teams.create!(display_name: name, block: @block, status: "active")
+    3.times do |index|
+      team.participants.create!(league: @league, display_name: "#{name} P#{index + 1}", position: index + 1, status: "active")
+    end
+    team
+  end
+
+  def create_match!(home_team:, away_team:, week: @week)
+    week.matches.create!(
+      league: @league,
+      phase: @phase,
+      block: @block,
+      home_team: home_team,
+      away_team: away_team,
+      scheduled_on: Date.new(2026, 4, 20),
+      scheduled_time: Time.zone.parse("20:00"),
+      status: "scheduled"
+    )
+  end
+end


### PR DESCRIPTION
## Summary
- `Decks::UsageSummary` service を新規追加。 引数 `week` に対し、 該当週内の全 `board_result` を走査して デッキ別 (= `home_deck_name`/`away_deck_name`) の使用者数 / 勝ち / 負け / 勝率を集計。 引き分け board は user_count にだけ反映、 勝敗には計上しない
- 並び順は使用者数降順 → 勝ち数降順 → deck_name 昇順
- `WeeksController#show` に `@deck_usage_summary` をセット、 `#deck_usage_csv` member action と route (`get :deck_usage_csv` on member) を追加。 CSV 出力は `Decks::UsageSummary#to_csv` で localized header (= ja: 「デッキ名,使用者数,勝ち,負け,勝率」) + 行データ
- `weeks/show.html.erb` に集計 article (= panel) を追加。 panel header に CSV ダウンロードボタン、 本体は `standings-table` クラスの table。 データなし時は CSV ボタン非表示 + empty 文言
- locales (ja/en) に `decks.usage.*` namespace を新設

## デッキの所在
metadata 通り `board_result.{home,away}_deck_name` (= 結果入力で recorder.rb 経由で保存) を一次データとして使用。 participant.deck_name や match_lineup_member.deck_name は使わない (= participant model には deck_name column 無し / lineup は出場順だけ管理)。

## Plane
- KAT-22 (= week 選択画面にデッキ別使用者数/勝敗集計の一覧 + CSV エクスポートを追加する)

## Test plan
- [x] `bin/rails test test/services/decks/usage_summary_test.rb` 緑 (6 runs / 20 assertions / 0 failures)
  - 空 week は entries 空
  - 使用者数 (unique participant) / wins / losses / win_rate 計算
  - sort (user_count desc → wins desc → deck_name asc)
  - 引き分け board (winner_side: nil) は user_count にカウント、 wins/losses は 0
  - 別 week の board は混入しない
  - CSV format (localized header + 0.500 形式)
- [x] `bin/rails test test/integration/regular_season_operations_flow_test.rb` 緑 (24 runs / 687 assertions)
  - 空 week show: 集計 panel + empty 文言 + CSV ボタン非表示
  - データありの week show: 集計表 + Aggregator Deck / Defender Deck 表示 + CSV link 表示
  - CSV エンドポイント: text/csv + Content-Disposition filename + 行データ
- [x] `bin/rails test` 緑 (68 runs / 990 assertions / 0 failures)