### PR TITLE
KAT-8 refactor: Standings の ranking ルールを WMGP module へ分離

### DIFF
--- a/apps/ledger/app/leagues/wmgp/league_module.rb
+++ b/apps/ledger/app/leagues/wmgp/league_module.rb
@@ -22,6 +22,10 @@ module Wmgp
       def standings
         ::Standings::Calculator
       end
+
+      def standings_ranking(_ranking_rule_key = nil)
+        @standings_ranking ||= ::Wmgp::Rules::StandingsRanking.new
+      end
     end
 
     class Renderers

--- a/apps/ledger/app/leagues/wmgp/rules/standings_ranking.rb
+++ b/apps/ledger/app/leagues/wmgp/rules/standings_ranking.rb
@@ -1,0 +1,65 @@
+module Wmgp
+  module Rules
+    class StandingsRanking
+      WIN_POINT = 3
+      WEIGHTS = [1_000_000_000_000, 1_000_000_000, 1_000_000, 1_000, 1].freeze
+
+      def call(team_stats:, teams_by_block:)
+        teams_by_block.each_with_object({}) do |(block_id, teams), result|
+          rows = teams.map { |team| build_row(team, team_stats[team.id]) }
+          sort_and_rank!(rows)
+          result[block_id] = rows
+        end
+      end
+
+      private
+
+      def build_row(team, stats)
+        points = stats.wins * WIN_POINT
+        goal_diff = stats.round_wins - stats.round_losses
+        round_board_diff = stats.board_wins - stats.board_losses
+        match_game_diff = stats.game_wins - stats.game_losses
+
+        ranking_values = [
+          points,
+          goal_diff,
+          round_board_diff,
+          match_game_diff,
+          stats.board_wins
+        ]
+
+        {
+          team: team,
+          wins: stats.wins,
+          points: points,
+          round_wins: stats.round_wins,
+          round_losses: stats.round_losses,
+          goal_diff: goal_diff,
+          round_board_diff: round_board_diff,
+          match_game_diff: match_game_diff,
+          board_wins_total: stats.board_wins,
+          ranking_values: ranking_values,
+          ranking_score: weighted_ranking_score(ranking_values)
+        }
+      end
+
+      def sort_and_rank!(rows)
+        rows.sort_by! { |row| row[:ranking_values].map { |value| -value } }
+
+        rows.each_with_index do |row, index|
+          row[:rank] = if index.zero?
+                         1
+                       elsif row[:ranking_values] == rows[index - 1][:ranking_values]
+                         rows[index - 1][:rank]
+                       else
+                         index + 1
+                       end
+        end
+      end
+
+      def weighted_ranking_score(values)
+        values.zip(WEIGHTS).sum { |value, weight| value * weight }
+      end
+    end
+  end
+end

--- a/apps/ledger/app/services/standings/aggregator.rb
+++ b/apps/ledger/app/services/standings/aggregator.rb
@@ -1,0 +1,121 @@
+module Standings
+  class Aggregator
+    Stats = Struct.new(
+      :wins, :round_wins, :round_losses,
+      :board_wins, :board_losses,
+      :game_wins, :game_losses,
+      keyword_init: true
+    ) do
+      def self.zero
+        new(
+          wins: 0, round_wins: 0, round_losses: 0,
+          board_wins: 0, board_losses: 0,
+          game_wins: 0, game_losses: 0
+        )
+      end
+    end
+
+    Aggregation = Struct.new(:team_stats, :teams_by_block, keyword_init: true)
+
+    def self.call(phase)
+      new(phase).call
+    end
+
+    def initialize(phase)
+      @phase = phase
+    end
+
+    def call
+      team_stats = Hash.new { |hash, key| hash[key] = Stats.zero }
+      collect_match_stats(team_stats)
+
+      teams_by_block = build_teams_by_block(team_stats)
+
+      Aggregation.new(team_stats: team_stats, teams_by_block: teams_by_block)
+    end
+
+    private
+
+    attr_reader :phase
+
+    def collect_match_stats(team_stats)
+      matches = phase.matches
+        .joins(:match_result)
+        .where.not(match_results: { decision_type: "bye" })
+        .includes(:match_result, rounds: :board_results)
+
+      matches.each do |match|
+        mr = match.match_result
+        next unless mr
+
+        [match.home_team_id, match.away_team_id].compact.each do |team_id|
+          accumulate_team_match(team_stats[team_id], match, mr, team_id)
+        end
+      end
+    end
+
+    def accumulate_team_match(stats, match, mr, team_id)
+      is_home = (team_id == match.home_team_id)
+
+      stats.wins += 1 if mr.winner_team_id == team_id
+
+      if is_home
+        stats.round_wins += mr.home_round_wins.to_i
+        stats.round_losses += mr.away_round_wins.to_i
+      else
+        stats.round_wins += mr.away_round_wins.to_i
+        stats.round_losses += mr.home_round_wins.to_i
+      end
+
+      match.rounds.each { |round| accumulate_team_round(stats, round, team_id) }
+    end
+
+    def accumulate_team_round(stats, round, team_id)
+      round_side = if team_id == round.home_team_id
+                     :home
+                   elsif team_id == round.away_team_id
+                     :away
+                   else
+                     return
+                   end
+
+      boards_won = 0
+      boards_lost = 0
+
+      round.board_results.each do |br|
+        next if br.winner_side.blank?
+
+        if round_side == :home
+          boards_won += 1 if br.winner_side == "home"
+          boards_lost += 1 if br.winner_side == "away"
+          stats.game_wins += br.home_game_wins.to_i
+          stats.game_losses += br.away_game_wins.to_i
+        else
+          boards_won += 1 if br.winner_side == "away"
+          boards_lost += 1 if br.winner_side == "home"
+          stats.game_wins += br.away_game_wins.to_i
+          stats.game_losses += br.home_game_wins.to_i
+        end
+      end
+
+      stats.board_wins += boards_won
+      stats.board_losses += boards_lost
+    end
+
+    def build_teams_by_block(team_stats)
+      teams = phase.league.teams
+        .where(id: team_stats.keys)
+        .includes(:block)
+        .index_by(&:id)
+
+      phase.blocks.includes(:teams).each do |block|
+        block.teams.each do |team|
+          team_stats[team.id] # ensure default entry
+          teams[team.id] ||= team
+        end
+      end
+
+      teams.values.group_by(&:block_id).reject { |block_id, _| block_id.nil? }
+    end
+  end
+end

--- a/apps/ledger/app/services/standings/calculator.rb
+++ b/apps/ledger/app/services/standings/calculator.rb
@@ -11,160 +11,19 @@ module Standings
     end
 
     def call
-      # 1. フェーズのマッチと関連データを一括取得
-      matches = @phase.matches
-        .joins(:match_result)
-        .where.not(match_results: { decision_type: "bye" })
-        .includes(:match_result, rounds: :board_results)
-
-      # 2. チームごとに集計
-      team_stats = Hash.new { |h, k| h[k] = empty_stats }
-
-      matches.each do |match|
-        mr = match.match_result
-        next unless mr
-
-        [match.home_team_id, match.away_team_id].compact.each do |team_id|
-          is_home = (team_id == match.home_team_id)
-          stats = team_stats[team_id]
-
-          # 勝利数
-          stats[:wins] += 1 if mr.winner_team_id == team_id
-
-          # 得点・失点（ラウンド勝数）
-          if is_home
-            stats[:round_wins] += mr.home_round_wins.to_i
-            stats[:round_losses] += mr.away_round_wins.to_i
-          else
-            stats[:round_wins] += mr.away_round_wins.to_i
-            stats[:round_losses] += mr.home_round_wins.to_i
-          end
-
-          # ラウンド・卓レベルの集計
-          match.rounds.each do |round|
-            round_side = if team_id == round.home_team_id
-                           :home
-                         elsif team_id == round.away_team_id
-                           :away
-                         else
-                           next
-                         end
-
-            boards_won = 0
-            boards_lost = 0
-
-            round.board_results.each do |br|
-              next unless br.winner_side.present?
-
-              if round_side == :home
-                boards_won += 1 if br.winner_side == "home"
-                boards_lost += 1 if br.winner_side == "away"
-                stats[:game_wins] += br.home_game_wins.to_i
-                stats[:game_losses] += br.away_game_wins.to_i
-              else
-                boards_won += 1 if br.winner_side == "away"
-                boards_lost += 1 if br.winner_side == "home"
-                stats[:game_wins] += br.away_game_wins.to_i
-                stats[:game_losses] += br.home_game_wins.to_i
-              end
-            end
-
-            stats[:board_wins] += boards_won
-            stats[:board_losses] += boards_lost
-          end
-        end
-      end
-
-      # 3. チーム情報を取得してブロック別にまとめる
-      teams = @phase.league.teams
-        .where(id: team_stats.keys)
-        .includes(:block)
-        .index_by(&:id)
-
-      # ブロック未割当チームも含める（ブロック内の全チームを対象）
-      @phase.blocks.includes(:teams).each do |block|
-        block.teams.each do |team|
-          team_stats[team.id] # ensure entry exists
-          teams[team.id] ||= team
-        end
-      end
-
-      # 4. 順位表を構築
-      standings_by_block = {}
-
-      teams.values.group_by { |t| t.block_id }.each do |block_id, block_teams|
-        next unless block_id
-
-        rows = block_teams.map do |team|
-          s = team_stats[team.id]
-          points = s[:wins] * 3
-          goal_diff = s[:round_wins] - s[:round_losses]
-          round_board_diff = s[:board_wins] - s[:board_losses]
-          match_game_diff = s[:game_wins] - s[:game_losses]
-
-          ranking_values = [
-            points,
-            goal_diff,
-            round_board_diff,
-            match_game_diff,
-            s[:board_wins]
-          ]
-
-          {
-            team: team,
-            wins: s[:wins],
-            points: points,
-            round_wins: s[:round_wins],
-            round_losses: s[:round_losses],
-            goal_diff: goal_diff,
-            round_board_diff: round_board_diff,
-            match_game_diff: match_game_diff,
-            board_wins_total: s[:board_wins],
-            ranking_values: ranking_values,
-            ranking_score: weighted_ranking_score(ranking_values)
-          }
-        end
-
-        # スコア降順ソート
-        rows.sort_by! { |r| r[:ranking_values].map { |value| -value } }
-
-        # 順位付与（同スコアは同順位）
-        rows.each_with_index do |row, i|
-          row[:rank] = if i == 0
-                         1
-                       elsif row[:ranking_values] == rows[i - 1][:ranking_values]
-                         rows[i - 1][:rank]
-                       else
-                         i + 1
-                       end
-        end
-
-        standings_by_block[block_id] = rows
-      end
-
-      standings_by_block
+      aggregation = Aggregator.call(@phase)
+      ranking_rule = resolve_ranking_rule
+      ranking_rule.call(
+        team_stats: aggregation.team_stats,
+        teams_by_block: aggregation.teams_by_block
+      )
     end
 
     private
 
-    def empty_stats
-      {
-        wins: 0, round_wins: 0, round_losses: 0,
-        board_wins: 0, board_losses: 0,
-        game_wins: 0, game_losses: 0
-      }
-    end
-
-    def weighted_ranking_score(values)
-      weights = [
-        1_000_000_000_000,
-        1_000_000_000,
-        1_000_000,
-        1_000,
-        1
-      ]
-
-      values.zip(weights).sum { |value, weight| value * weight }
+    def resolve_ranking_rule
+      league_module = ::RuleModules::Registry.fetch(::RuleSets::Registry.default_key)
+      league_module.rules.standings_ranking(@phase.ranking_rule_key)
     end
   end
 end

--- a/apps/ledger/test/leagues/wmgp/rules/standings_ranking_test.rb
+++ b/apps/ledger/test/leagues/wmgp/rules/standings_ranking_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class Wmgp::Rules::StandingsRankingTest < ActiveSupport::TestCase
+  setup do
+    @block_a_id = SecureRandom.uuid
+    @block_b_id = SecureRandom.uuid
+    @alpha = build_team("Alpha", block_id: @block_a_id)
+    @beta = build_team("Beta", block_id: @block_a_id)
+    @gamma = build_team("Gamma", block_id: @block_a_id)
+    @delta = build_team("Delta", block_id: @block_b_id)
+  end
+
+  test "awards 3 points per win and ranks by the WMGP 5-tier tiebreaker" do
+    team_stats = {
+      @alpha.id => stats(wins: 2, round_wins: 4, round_losses: 1, board_wins: 8, board_losses: 4),
+      @beta.id  => stats(wins: 2, round_wins: 5, round_losses: 2, board_wins: 6, board_losses: 5),
+      @gamma.id => stats(wins: 0, round_wins: 1, round_losses: 7, board_wins: 2, board_losses: 9)
+    }
+    teams_by_block = { @block_a_id => [@alpha, @beta, @gamma] }
+
+    rows = Wmgp::Rules::StandingsRanking.new.call(team_stats: team_stats, teams_by_block: teams_by_block).fetch(@block_a_id)
+
+    assert_equal %w[Alpha Beta Gamma], rows.map { |row| row[:team].display_name },
+      "Alpha and Beta tie on points (6) and goal_diff (3); Alpha wins on round_board_diff (4 vs 1)"
+    assert_equal [1, 2, 3], rows.map { |row| row[:rank] }
+    assert_equal [6, 6, 0], rows.map { |row| row[:points] }
+    assert_equal [3, 3, -6], rows.map { |row| row[:goal_diff] }
+  end
+
+  test "assigns the same rank to teams whose ranking_values match exactly" do
+    team_stats = {
+      @alpha.id => stats(wins: 1, round_wins: 2, round_losses: 2, board_wins: 3, board_losses: 3, game_wins: 6, game_losses: 6),
+      @beta.id  => stats(wins: 1, round_wins: 2, round_losses: 2, board_wins: 3, board_losses: 3, game_wins: 6, game_losses: 6),
+      @gamma.id => stats(wins: 0, round_wins: 0, round_losses: 2, board_wins: 0, board_losses: 3)
+    }
+    teams_by_block = { @block_a_id => [@alpha, @beta, @gamma] }
+
+    rows = Wmgp::Rules::StandingsRanking.new.call(team_stats: team_stats, teams_by_block: teams_by_block).fetch(@block_a_id)
+
+    tied_ranks = rows.first(2).map { |row| row[:rank] }
+    assert_equal [1, 1], tied_ranks, "Alpha and Beta share rank 1 because all 5 tiebreak values match"
+    assert_equal 3, rows.last[:rank]
+  end
+
+  test "produces independent ranking results for each block" do
+    team_stats = {
+      @alpha.id => stats(wins: 1, round_wins: 2, round_losses: 0, board_wins: 4, board_losses: 0),
+      @delta.id => stats(wins: 0, round_wins: 0, round_losses: 0, board_wins: 0, board_losses: 0)
+    }
+    teams_by_block = { @block_a_id => [@alpha], @block_b_id => [@delta] }
+
+    result = Wmgp::Rules::StandingsRanking.new.call(team_stats: team_stats, teams_by_block: teams_by_block)
+
+    assert_equal [1], result.fetch(@block_a_id).map { |row| row[:rank] }
+    assert_equal [1], result.fetch(@block_b_id).map { |row| row[:rank] }
+  end
+
+  private
+
+  def stats(**overrides)
+    defaults = { wins: 0, round_wins: 0, round_losses: 0, board_wins: 0, board_losses: 0, game_wins: 0, game_losses: 0 }
+    Standings::Aggregator::Stats.new(**defaults.merge(overrides))
+  end
+
+  def build_team(name, block_id:)
+    Team.new(id: SecureRandom.uuid, display_name: name, block_id: block_id, status: "active")
+  end
+end


### PR DESCRIPTION
## Summary
Phase 2 PoC (KAT-6) の本丸。 `Standings::Calculator` から WMGP 固有の ranking ルール (= `wins * 3` 勝ち点 + 5 段階 tiebreak + WEIGHTS) を WMGP module 側へ分離し、 Core 側は ranking rule を抽象 IF 経由で呼ぶ形に切り替え。 振る舞いは不変。

## 構造
- **Core (= app/services/standings/)**
  - `Aggregator` (新規) — phase の matches/rounds/board_results から league 非依存な `team_stats` を集める。 `Stats` Struct + `Aggregation` Struct で型付け
  - `Calculator` (大幅縮小) — facade。 (1) `Aggregator.call(phase)` で stats、 (2) `RuleModules::Registry.fetch(RuleSets::Registry.default_key).rules.standings_ranking(phase.ranking_rule_key)` で ranking rule strategy 取得、 (3) `strategy.call(team_stats:, teams_by_block:)` 実行
- **WMGP module (= app/leagues/wmgp/rules/)**
  - `Wmgp::Rules::StandingsRanking` (新規) — `WIN_POINT = 3`、 `WEIGHTS = [10^12, 10^9, 10^6, 10^3, 1]`、 5 段階 tiebreak (= points → goal_diff → round_board_diff → match_game_diff → board_wins) の sort + 同値時の同順位付与
  - `Wmgp::LeagueModule::Rules#standings_ranking(_ranking_rule_key = nil)` — IF 実装。 `ranking_rule_key` 引数は現状未使用 (= WMGP 標準 strategy 単一返却)、 将来 `wmgp_regular` / `wmgp_playoff` の切り替えに使う slot として残す

## 設計判断 (要点)
- **`Phase#rule_module` helper は今回追加しない**: 既存 `phase.rule_module_key` の現実値は `stage_asset.match_rule_key` (例: `"md_team_3v3_best_of_rounds"`) で、 `Wmgp::LeagueModule#key` (`"wmgp"`) と一致しない。 直接 lookup すると本番 phase で KeyError。 description「`phase.ranking_rule_key` 経由」 の指示に従い、 module 解決は `RuleSets::Registry.default_key` 経由 (= 現状単一 module の PoC 文脈で許容、 KAT-11 で `default_key` 自体を消す予定)
- **Core 側にも残る "wmgp" 直書きは無し**: Calculator は `RuleSets::Registry.default_key` (= 値が "wmgp") を間接参照、 リテラルとしては Core ファイルに "wmgp" の出現なし。 KAT-11 完走で完全閉域化
- **`Wmgp::LeagueModule::Rules#standings` (既存 passthrough method) は維持**: KAT-7 で導入された IF skeleton、 KAT-9 / KAT-10 (renderer 系分離) との整合のため温存。 削除は別 Issue 範疇

## Plane
- KAT-8 (= 順位計算 (Standings::Calculator) を Core 抽象 + WMGP module に分離)
- 親 Issue: KAT-6 (Phase 2 PoC 節目)

## 受入条件 (達成状況)
- [x] `Standings::Calculator` に `wins * 3` や WMGP 固有 tiebreak 順序が直接書かれていない (= grep で WIN_POINT/WEIGHTS/ranking_values は `app/leagues/wmgp/rules/` のみ)
- [x] WMGP のランキングルール (勝ち点 / tiebreak) は WMGP module 側 (`Wmgp::Rules::StandingsRanking`) に閉じ込められている
- [x] Core 側は ranking rule を抽象 IF (`RuleModules::Registry` → `LeagueModule#rules.standings_ranking`) 経由で呼ぶ
- [x] 既存 WMGP league で順位表の集計結果が PoC 前後で完全一致 (= 既存 `test/services/standings/calculator_test.rb` 5 件 + WMGP module unit test 3 件すべて緑)
- [x] テスト緑 (`bin/rails test` 71 runs / 998 assertions / 0 failures)

## Test plan
- [x] `bin/rails test test/services/standings/` (既存 5 tests, public IF 経由の regression 保証)
- [x] `bin/rails test test/services/rule_modules/` (既存 3 tests, registry / module 登録確認)
- [x] `bin/rails test test/leagues/wmgp/rules/standings_ranking_test.rb` (新規 3 tests, WMGP ranking strategy の直接 unit test: WIN_POINT=3, 5 段階 tiebreak の動作、 同値同順位、 block 別独立)
- [x] `bin/rails test` 全 71 runs 緑