### PR TITLE
KAT-23 infra: main 直 merge を防ぐ branch-base-check CI を導入

### DIFF
--- a/.github/workflows/branch-base-check.yml
+++ b/.github/workflows/branch-base-check.yml
@@ -1,0 +1,22 @@
+name: branch-base-check
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  require-staging-head:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require staging as PR head
+        if: github.head_ref != 'staging'
+        run: |
+          echo "::error::main は staging からの PR のみ受け付けます (現在の head: ${{ github.head_ref }})"
+          exit 1
+      - name: OK
+        if: github.head_ref == 'staging'
+        run: |
+          echo "head=staging, OK"

--- a/docs/git-workflow.md
+++ b/docs/git-workflow.md
@@ -49,6 +49,20 @@ GitHub 側:
   - direct push 禁止 (admin も bypass 不可、 `enforce_admins=true`)
   - PR 経由のみ
   - CI (`test` job) 緑が merge 必須
+  - **main への PR は head=`staging` 以外を CI で reject** (`branch-base-check` workflow)
+    - `feature/*` から main への直 PR は `branch-base-check` が fail して merge 不可
+    - 必ず `feature/* -> staging -> main` の 2 段を経由する
+
+緊急時の例外 (= staging を経由できない hotfix):
+
+通常は hotfix も `staging` 経由で出す (= `staging` を一旦 main に揃えてから `feature/hotfix-*` を切る)。 どうしても staging を経由できない場合だけ次の手順で一時的に bypass する:
+
+1. GitHub 設定 (`Settings -> Branches -> main`) で required status checks から `branch-base-check` を一時除外する
+2. hotfix branch -> main で PR を作って merge
+3. main を staging に揃え直す (= `staging` を `main` に reset hard + force push)
+4. required status checks に `branch-base-check` を戻す
+
+例外操作は事後に Plane Issue に経緯を残す。
 
 deploy 対応:
 


### PR DESCRIPTION
## Summary

- `.github/workflows/branch-base-check.yml` を追加。 main への PR で `head_ref != 'staging'` なら CI fail させる
- `docs/git-workflow.md` に CI guard の説明と緊急時の例外手順 (= 一時 branch protection 解除) を追記

これにより AI / 人間双方が main 直 merge できなくなり、 docs/git-workflow.md の「staging -> main 2 段」 運用が仕組みで担保される。

事前に origin/staging を origin/main に fast-forward 追従させた (= 42 commits behind / 0 ahead だったため安全に ff merge)。

## Test plan

- [x] `bin/rails test` 緑 (= 71 runs, 998 assertions, 0 failures)
- [x] 本 PR の head は staging なので `branch-base-check` が pass することを確認 (= 仕組みの dogfooding)
- [ ] merge 後に branch protection の required status checks に `branch-base-check` を追加する

Issue: KAT-23