### PR TITLE
KAT-24 feat: スコアシート (結果カード) にチームアイコンを表示

### DIFF
--- a/apps/ledger/app/controllers/teams_controller.rb
+++ b/apps/ledger/app/controllers/teams_controller.rb
@@ -62,7 +62,7 @@ class TeamsController < ApplicationController
   end
 
   def team_params
-    params.require(:team).permit(:display_name, :status, :notes)
+    params.require(:team).permit(:display_name, :status, :notes, :icon)
   end
 
   def safe_return_to(value)

--- a/apps/ledger/app/models/team.rb
+++ b/apps/ledger/app/models/team.rb
@@ -2,6 +2,8 @@ class Team < ApplicationRecord
   belongs_to :league
   belongs_to :block, optional: true
 
+  has_one_attached :icon
+
   has_many :participants, dependent: :destroy
   has_many :home_matches, class_name: "Match", foreign_key: :home_team_id, dependent: :restrict_with_exception
   has_many :away_matches, class_name: "Match", foreign_key: :away_team_id, dependent: :restrict_with_exception

--- a/apps/ledger/app/services/match_exports/result_card_renderer.rb
+++ b/apps/ledger/app/services/match_exports/result_card_renderer.rb
@@ -154,6 +154,21 @@ module MatchExports
             }
             .versus-team.home { flex-direction: row; }
             .versus-team.away { flex-direction: row-reverse; }
+            .team-block {
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              gap: 8px;
+              overflow: hidden;
+            }
+            .team-icon {
+              width: 72px;
+              height: 72px;
+              object-fit: contain;
+              border-radius: 8px;
+              background: #fff;
+              flex-shrink: 0;
+            }
             .team-name {
               color: #fff;
               font-size: 28px;
@@ -335,14 +350,20 @@ module MatchExports
       <<~HTML
         <div class="versus">
           <div class="versus-team home">
-            <div class="team-name">#{h match.home_team.display_name}</div>
+            <div class="team-block">
+              #{team_icon_html(match.home_team)}
+              <div class="team-name">#{h match.home_team.display_name}</div>
+            </div>
             <div class="player-list">
               #{left_players.map { |n| %(<div class="player-tag">#{h n}</div>) }.join}
             </div>
           </div>
           <div class="versus-center">VS</div>
           <div class="versus-team away">
-            <div class="team-name">#{h match.away_team.display_name}</div>
+            <div class="team-block">
+              #{team_icon_html(match.away_team)}
+              <div class="team-name">#{h match.away_team.display_name}</div>
+            </div>
             <div class="player-list">
               #{right_players.map { |n| %(<div class="player-tag">#{h n}</div>) }.join}
             </div>
@@ -489,6 +510,18 @@ module MatchExports
     def header_image_data_uri
       blob = match.league.header_image.blob
       encoded = Base64.strict_encode64(match.league.header_image.download)
+      "data:#{blob.content_type};base64,#{encoded}"
+    end
+
+    def team_icon_html(team)
+      return "" unless team.icon.attached?
+
+      %(<img class="team-icon" src="#{team_icon_data_uri(team)}" alt="">)
+    end
+
+    def team_icon_data_uri(team)
+      blob = team.icon.blob
+      encoded = Base64.strict_encode64(team.icon.download)
       "data:#{blob.content_type};base64,#{encoded}"
     end
   end

--- a/apps/ledger/app/views/teams/_form.html.erb
+++ b/apps/ledger/app/views/teams/_form.html.erb
@@ -23,6 +23,19 @@
     <%= form.text_area :notes, rows: 4 %>
   </div>
 
+  <div class="field-grid">
+    <div class="field">
+      <%= form.label :icon, t("teams.form.icon") %>
+      <%= form.file_field :icon, accept: "image/png,image/jpeg,image/webp" %>
+      <p class="ghost-note"><%= t("teams.form.icon_hint") %></p>
+      <% if team.icon.attached? %>
+        <div class="image-preview-card">
+          <%= image_tag team.icon, alt: t("teams.form.icon"), class: "image-preview-card__image" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
   <div class="page-actions">
     <%= link_to t("actions.back"), team.persisted? ? league_team_path(league_id: league, id: team) : league_teams_path(league_id: league), class: "button" %>
     <%= form.submit(team.persisted? ? t("teams.submit_update") : t("teams.submit_create"), class: "button button--primary") %>

--- a/apps/ledger/config/locales/en.yml
+++ b/apps/ledger/config/locales/en.yml
@@ -254,6 +254,8 @@ en:
       status: Status
       status_hint: "Draft leagues allow deletion. After publishing, use %{withdrawn_label} when a team drops."
       notes: Notes
+      icon: Team icon
+      icon_hint: Shown above the team name on the score sheet. A near-square image works best.
     delete_confirm: Delete this team?
     delete_hint: Only teams that are not used in matches can be deleted.
     back_to_result_entry: Back to result entry

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -254,6 +254,8 @@ ja:
       status: 状態
       status_hint: "%{draft_label} のリーグでは削除できます。実施中の離脱は %{withdrawn_label} を使います。"
       notes: メモ
+      icon: チームアイコン
+      icon_hint: スコアシートのチーム名の上に表示します。正方形に近い画像を推奨。
     delete_confirm: このチームを削除します。よろしいですか？
     delete_hint: 対戦で未使用のチームだけ削除できます。
     back_to_result_entry: 結果入力に戻る

--- a/apps/ledger/test/services/match_exports/result_card_renderer_test.rb
+++ b/apps/ledger/test/services/match_exports/result_card_renderer_test.rb
@@ -52,6 +52,27 @@ class MatchExports::ResultCardRendererTest < ActiveSupport::TestCase
     assert_includes footer_html, '<div class="footer-score">2 - 0</div>'
   end
 
+  test "versus header omits team icon when none is attached" do
+    match = create_match_for_renderer_test!(home_name: "Alpha Team", away_name: "Beta Team")
+
+    html = MatchExports::ResultCardRenderer.new(match).send(:versus_html)
+
+    assert_not_includes html, "team-icon"
+  end
+
+  test "versus header embeds team icon as data uri when attached" do
+    match = create_match_for_renderer_test!(home_name: "Alpha Team", away_name: "Beta Team")
+    match.home_team.icon.attach(
+      io: StringIO.new(one_by_one_png),
+      filename: "home_icon.png",
+      content_type: "image/png"
+    )
+
+    html = MatchExports::ResultCardRenderer.new(match.reload).send(:versus_html)
+
+    assert_includes html, %(<img class="team-icon" src="data:image/png;base64,)
+  end
+
   private
 
   def create_match_for_renderer_test!(home_name:, away_name:)
@@ -92,6 +113,12 @@ class MatchExports::ResultCardRendererTest < ActiveSupport::TestCase
       away_game_wins: score[1],
       result_status: "confirmed",
       winner_side: winner_side
+    )
+  end
+
+  def one_by_one_png
+    Base64.decode64(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
     )
   end
 end


### PR DESCRIPTION
## 概要
運営者要望 (Discord): チームアイコンをスコアシートに表示したい (チーム名の上)。チーム単位でアイコンを 1 回登録し、結果カード (PNG) がそこから参照する設計。

## 変更
- Team に `has_one_attached :icon` (League header_image と同パターン、migration 不要)
- チーム管理画面でアイコンをアップロード / 差し替え / プレビュー
- 結果カード PNG の versus セクションで home/away チーム名の**上**にアイコンを Base64 埋め込み描画
- アイコン未登録チームは従来通り (名前のみ、レイアウト崩れなし)

## テスト
- `bin/rails test` 全緑 (73 runs / 1002 assertions / 0 failures)
- result_card_renderer にアイコン添付有無の検証を 2 件追加

## 残作業: 実機 PNG 目視
staging でチームにアイコンを登録 → 結果カード生成で最終レイアウト確認。

Plane: KAT-24