### PR TITLE
KAT-24/32/33: チームアイコン機能群を本番へ昇格

### DIFF
--- a/apps/ledger/app/assets/stylesheets/application.css
+++ b/apps/ledger/app/assets/stylesheets/application.css
@@ -1324,3 +1324,36 @@ h2 {
 /* positive/negative diff coloring */
 .standings-table td.standings-plus { color: var(--success); }
 .standings-table td.standings-minus { color: var(--danger); }
+
+/* ── Team icon display ── */
+.team-thumb-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.team-thumb {
+  flex-shrink: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  object-fit: contain;
+  border-radius: 0.5rem;
+  background: #fff;
+  border: 1px solid var(--line);
+}
+
+.team-show-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.team-show-icon {
+  flex-shrink: 0;
+  width: 4rem;
+  height: 4rem;
+  object-fit: contain;
+  border-radius: 0.75rem;
+  background: #fff;
+  border: 1px solid var(--line);
+}

--- a/apps/ledger/app/controllers/teams_controller.rb
+++ b/apps/ledger/app/controllers/teams_controller.rb
@@ -62,7 +62,7 @@ class TeamsController < ApplicationController
   end
 
   def team_params
-    params.require(:team).permit(:display_name, :status, :notes)
+    params.require(:team).permit(:display_name, :status, :notes, :icon)
   end
 
   def safe_return_to(value)

--- a/apps/ledger/app/models/team.rb
+++ b/apps/ledger/app/models/team.rb
@@ -2,6 +2,8 @@ class Team < ApplicationRecord
   belongs_to :league
   belongs_to :block, optional: true
 
+  has_one_attached :icon
+
   has_many :participants, dependent: :destroy
   has_many :home_matches, class_name: "Match", foreign_key: :home_team_id, dependent: :restrict_with_exception
   has_many :away_matches, class_name: "Match", foreign_key: :away_team_id, dependent: :restrict_with_exception

--- a/apps/ledger/app/services/match_exports/result_card_renderer.rb
+++ b/apps/ledger/app/services/match_exports/result_card_renderer.rb
@@ -78,13 +78,19 @@ module MatchExports
       export = match.exports.find_by(export_type: EXPORT_TYPE)
       return false unless export&.generated_at
 
-      last_change = [
-        match.match_result&.updated_at,
-        match.rounds.maximum(:updated_at)
-      ].compact.max
-      return true unless last_change
+      last = last_source_change
+      return true unless last
 
-      export.generated_at >= last_change
+      export.generated_at >= last
+    end
+
+    def last_source_change
+      [
+        match.match_result&.updated_at,
+        match.rounds.maximum(:updated_at),
+        match.home_team&.icon&.attachment&.created_at,
+        match.away_team&.icon&.attachment&.created_at
+      ].compact.max
     end
 
     def h(value)

--- a/apps/ledger/app/services/match_exports/result_card_renderer.rb
+++ b/apps/ledger/app/services/match_exports/result_card_renderer.rb
@@ -154,6 +154,21 @@ module MatchExports
             }
             .versus-team.home { flex-direction: row; }
             .versus-team.away { flex-direction: row-reverse; }
+            .team-block {
+              display: flex;
+              flex-direction: column;
+              align-items: center;
+              gap: 8px;
+              overflow: hidden;
+            }
+            .team-icon {
+              width: 72px;
+              height: 72px;
+              object-fit: contain;
+              border-radius: 8px;
+              background: #fff;
+              flex-shrink: 0;
+            }
             .team-name {
               color: #fff;
               font-size: 28px;
@@ -335,14 +350,20 @@ module MatchExports
       <<~HTML
         <div class="versus">
           <div class="versus-team home">
-            <div class="team-name">#{h match.home_team.display_name}</div>
+            <div class="team-block">
+              #{team_icon_html(match.home_team)}
+              <div class="team-name">#{h match.home_team.display_name}</div>
+            </div>
             <div class="player-list">
               #{left_players.map { |n| %(<div class="player-tag">#{h n}</div>) }.join}
             </div>
           </div>
           <div class="versus-center">VS</div>
           <div class="versus-team away">
-            <div class="team-name">#{h match.away_team.display_name}</div>
+            <div class="team-block">
+              #{team_icon_html(match.away_team)}
+              <div class="team-name">#{h match.away_team.display_name}</div>
+            </div>
             <div class="player-list">
               #{right_players.map { |n| %(<div class="player-tag">#{h n}</div>) }.join}
             </div>
@@ -489,6 +510,18 @@ module MatchExports
     def header_image_data_uri
       blob = match.league.header_image.blob
       encoded = Base64.strict_encode64(match.league.header_image.download)
+      "data:#{blob.content_type};base64,#{encoded}"
+    end
+
+    def team_icon_html(team)
+      return "" unless team.icon.attached?
+
+      %(<img class="team-icon" src="#{team_icon_data_uri(team)}" alt="">)
+    end
+
+    def team_icon_data_uri(team)
+      blob = team.icon.blob
+      encoded = Base64.strict_encode64(team.icon.download)
       "data:#{blob.content_type};base64,#{encoded}"
     end
   end

--- a/apps/ledger/app/views/teams/_form.html.erb
+++ b/apps/ledger/app/views/teams/_form.html.erb
@@ -23,6 +23,19 @@
     <%= form.text_area :notes, rows: 4 %>
   </div>
 
+  <div class="field-grid">
+    <div class="field">
+      <%= form.label :icon, t("teams.form.icon") %>
+      <%= form.file_field :icon, accept: "image/png,image/jpeg,image/webp" %>
+      <p class="ghost-note"><%= t("teams.form.icon_hint") %></p>
+      <% if team.icon.attached? %>
+        <div class="image-preview-card">
+          <%= image_tag team.icon, alt: t("teams.form.icon"), class: "image-preview-card__image" %>
+        </div>
+      <% end %>
+    </div>
+  </div>
+
   <div class="page-actions">
     <%= link_to t("actions.back"), team.persisted? ? league_team_path(league_id: league, id: team) : league_teams_path(league_id: league), class: "button" %>
     <%= form.submit(team.persisted? ? t("teams.submit_update") : t("teams.submit_create"), class: "button button--primary") %>

--- a/apps/ledger/app/views/teams/index.html.erb
+++ b/apps/ledger/app/views/teams/index.html.erb
@@ -27,9 +27,14 @@
     <% @teams.each do |team| %>
       <article class="panel">
         <div class="panel-header">
-          <div>
-            <h2><%= link_to team.display_name, league_team_path(league_id: @league, id: team) %></h2>
-            <p class="muted"><%= t("labels.participants_count", count: team.participants.size) %></p>
+          <div class="team-thumb-row">
+            <% if team.icon.attached? %>
+              <%= image_tag team.icon, alt: team.display_name, class: "team-thumb" %>
+            <% end %>
+            <div>
+              <h2><%= link_to team.display_name, league_team_path(league_id: @league, id: team) %></h2>
+              <p class="muted"><%= t("labels.participants_count", count: team.participants.size) %></p>
+            </div>
           </div>
           <div class="page-actions">
             <%= status_badge translated_enum("enums.team.status", team.status), "neutral" %>

--- a/apps/ledger/app/views/teams/show.html.erb
+++ b/apps/ledger/app/views/teams/show.html.erb
@@ -8,10 +8,15 @@
 ]) %>
 
 <section class="page-header">
-  <div>
-    <p class="eyebrow"><%= t("teams.eyebrow") %></p>
-    <h1><%= @team.display_name %></h1>
-    <p class="muted"><%= [translated_enum("enums.team.status", @team.status), @team.block&.name, t("labels.participants_count", count: @participants.size)].compact.join(" / ") %></p>
+  <div class="team-show-header">
+    <% if @team.icon.attached? %>
+      <%= image_tag @team.icon, alt: @team.display_name, class: "team-show-icon" %>
+    <% end %>
+    <div>
+      <p class="eyebrow"><%= t("teams.eyebrow") %></p>
+      <h1><%= @team.display_name %></h1>
+      <p class="muted"><%= [translated_enum("enums.team.status", @team.status), @team.block&.name, t("labels.participants_count", count: @participants.size)].compact.join(" / ") %></p>
+    </div>
   </div>
   <div class="page-actions">
     <% if @return_to.present? %>

--- a/apps/ledger/config/locales/en.yml
+++ b/apps/ledger/config/locales/en.yml
@@ -254,6 +254,8 @@ en:
       status: Status
       status_hint: "Draft leagues allow deletion. After publishing, use %{withdrawn_label} when a team drops."
       notes: Notes
+      icon: Team icon
+      icon_hint: Shown above the team name on the score sheet. A near-square image works best.
     delete_confirm: Delete this team?
     delete_hint: Only teams that are not used in matches can be deleted.
     back_to_result_entry: Back to result entry

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -254,6 +254,8 @@ ja:
       status: 状態
       status_hint: "%{draft_label} のリーグでは削除できます。実施中の離脱は %{withdrawn_label} を使います。"
       notes: メモ
+      icon: チームアイコン
+      icon_hint: スコアシートのチーム名の上に表示します。正方形に近い画像を推奨。
     delete_confirm: このチームを削除します。よろしいですか？
     delete_hint: 対戦で未使用のチームだけ削除できます。
     back_to_result_entry: 結果入力に戻る

--- a/apps/ledger/test/services/match_exports/result_card_renderer_test.rb
+++ b/apps/ledger/test/services/match_exports/result_card_renderer_test.rb
@@ -52,6 +52,27 @@ class MatchExports::ResultCardRendererTest < ActiveSupport::TestCase
     assert_includes footer_html, '<div class="footer-score">2 - 0</div>'
   end
 
+  test "versus header omits team icon when none is attached" do
+    match = create_match_for_renderer_test!(home_name: "Alpha Team", away_name: "Beta Team")
+
+    html = MatchExports::ResultCardRenderer.new(match).send(:versus_html)
+
+    assert_not_includes html, "team-icon"
+  end
+
+  test "versus header embeds team icon as data uri when attached" do
+    match = create_match_for_renderer_test!(home_name: "Alpha Team", away_name: "Beta Team")
+    match.home_team.icon.attach(
+      io: StringIO.new(one_by_one_png),
+      filename: "home_icon.png",
+      content_type: "image/png"
+    )
+
+    html = MatchExports::ResultCardRenderer.new(match.reload).send(:versus_html)
+
+    assert_includes html, %(<img class="team-icon" src="data:image/png;base64,)
+  end
+
   private
 
   def create_match_for_renderer_test!(home_name:, away_name:)
@@ -92,6 +113,12 @@ class MatchExports::ResultCardRendererTest < ActiveSupport::TestCase
       away_game_wins: score[1],
       result_status: "confirmed",
       winner_side: winner_side
+    )
+  end
+
+  def one_by_one_png
+    Base64.decode64(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
     )
   end
 end

--- a/apps/ledger/test/services/match_exports/result_card_renderer_test.rb
+++ b/apps/ledger/test/services/match_exports/result_card_renderer_test.rb
@@ -73,6 +73,73 @@ class MatchExports::ResultCardRendererTest < ActiveSupport::TestCase
     assert_includes html, %(<img class="team-icon" src="data:image/png;base64,)
   end
 
+  test "last_source_change is nil when no rounds, match_result, or team icons exist" do
+    match = create_match_for_renderer_test!(home_name: "Alpha Team", away_name: "Beta Team")
+    renderer = MatchExports::ResultCardRenderer.new(match.reload)
+
+    assert_nil renderer.send(:last_source_change)
+  end
+
+  test "last_source_change reflects home team icon attachment time" do
+    match = create_match_for_renderer_test!(home_name: "Alpha Team", away_name: "Beta Team")
+    before_attach = Time.current
+    match.home_team.icon.attach(
+      io: StringIO.new(one_by_one_png),
+      filename: "home_icon.png",
+      content_type: "image/png"
+    )
+    attachment = match.home_team.reload.icon.attachment
+
+    renderer = MatchExports::ResultCardRenderer.new(match.reload)
+    result = renderer.send(:last_source_change)
+
+    assert_not_nil result
+    assert_operator result, :>=, before_attach
+    assert_operator result, :>=, attachment.created_at
+  end
+
+  test "last_source_change reflects away team icon attachment time" do
+    match = create_match_for_renderer_test!(home_name: "Alpha Team", away_name: "Beta Team")
+    before_attach = Time.current
+    match.away_team.icon.attach(
+      io: StringIO.new(one_by_one_png),
+      filename: "away_icon.png",
+      content_type: "image/png"
+    )
+    attachment = match.away_team.reload.icon.attachment
+
+    renderer = MatchExports::ResultCardRenderer.new(match.reload)
+    result = renderer.send(:last_source_change)
+
+    assert_not_nil result
+    assert_operator result, :>=, before_attach
+    assert_operator result, :>=, attachment.created_at
+  end
+
+  test "last_source_change returns most recent among rounds, match_result, and team icons" do
+    match = create_match_for_renderer_test!(home_name: "Alpha Team", away_name: "Beta Team")
+    match.rounds.create!(
+      number: 1,
+      home_team: match.home_team,
+      away_team: match.away_team,
+      result_status: "partial",
+      winner_team: nil
+    )
+    match.home_team.icon.attach(
+      io: StringIO.new(one_by_one_png),
+      filename: "home_icon.png",
+      content_type: "image/png"
+    )
+    icon_attached_at = match.home_team.reload.icon.attachment.created_at
+
+    renderer = MatchExports::ResultCardRenderer.new(match.reload)
+    result = renderer.send(:last_source_change)
+
+    assert_not_nil result
+    assert_operator result, :>=, match.rounds.maximum(:updated_at)
+    assert_operator result, :>=, icon_attached_at
+  end
+
   private
 
   def create_match_for_renderer_test!(home_name:, away_name:)

--- a/docs/deployment-environments.md
+++ b/docs/deployment-environments.md
@@ -104,6 +104,25 @@ seed profile:
 
 staging の現在値: `LEDGER_SEED_PROFILE=demo`、 `APP_HOST=katorin2-staging.codenica.dev`。
 
+## Active Storage (添付ファイルの永続化)
+
+Active Storage は `DiskService` (`/rails/storage`)。 これを **永続ボリュームにマウントしないと、 デプロイ (`docker compose up` でコンテナ再作成) のたびに blob 実体ファイルが全消失**する (DB の添付レコードだけ残り画像が壊れる)。 KAT-34。
+
+staging (`/opt/katorin2-staging/docker-compose.yml`) / production (`/opt/katorin2/docker-compose.yml`) とも、 app service に名前付きボリュームを割り当てる:
+
+```yaml
+services:
+  app:
+    volumes:
+      - katorin2_staging_storage:/rails/storage   # prod は katorin2_storage
+volumes:
+  katorin2_staging_storage:
+```
+
+- image digest の sed 置換 (deploy.yml / deploy-staging.yml) とは非干渉なので、 ボリューム設定は deploy をまたいで残る。
+- 生成済みカード (`public/generated`) は派生データなのでボリューム不要 (デプロイ後の初回 download で自動再生成される)。
+- VPS の compose は repo 管理外。 新規ホスト構築時はこのボリューム設定を忘れないこと。
+
 ## branch 方針
 
 - `main` から production deploy (`.github/workflows/deploy.yml`) と staging deploy (`.github/workflows/deploy-staging.yml`) が並列に走る

--- a/docs/wmgp-s8-pain-analysis-2026-05.md
+++ b/docs/wmgp-s8-pain-analysis-2026-05.md
@@ -1,0 +1,95 @@
+# WMGP Season 8 運営・アプリ 困りごと洗い出し (2026-05-20)
+
+## 調査方法
+
+3 層を突き合わせて「運営の手作業」「アプリの穴」を洗い出した。
+
+- **Discord ログ**: DiscordChatExporter で公開チャンネル + 運営内部チャンネルを JSON エクスポート (s8 期間 = 2026-03 以降)。質問部屋 (JP/EN/ID)、s8-試合結果 / 集計 / メンバー変更 / チーム移動、運営チャット / help-judge / keikoku 等。
+- **本番 DB**: staging (`katorin2_staging`) の本番 snapshot を read-only 集計 ([`staging-on-demand.md`](staging-on-demand.md))。6 週経過時点。
+- **コード**: `apps/ledger` を読み、公開ページ有無 / locale 実装を確定。
+
+個人名・MD ID 等は本ドキュメントから除外し、件数とパターンのみ記載する。
+
+## 全体像 (本番 snapshot)
+
+- teams **67** / participants **541** (全員 status=active) / matches **184** / match_results 183 / exports (match_result_card) **183**
+- league `wmgp` は 6 週進行中だが status=`draft` のまま。phase = 予選(regular_season) + 予選ステージ(playoff)。
+
+---
+
+## 既に着手済み (= 洗い出し対象外)
+
+運営チャットの要望 → 実装が既に回っている。直近コミットの多くがこのチャット由来:
+
+| 要望 (運営チャット) | 対応 |
+|---|---|
+| 順位計算式 (勝点→R勝数→…→選手勝数 / 旧 Excel 手計算) | KAT-8 |
+| week のデッキ別集計 + CSV | KAT-22 |
+| home/away チーム管理への導線 | KAT-21 |
+| スコアシートにチームアイコン | KAT-24 (staging) |
+
+過去バグ (1-1/0-1 入力エラー・iPhone 削除ボタン・3-0 が W 表記にならない・W/L 色・多言語化エラー・画像生成停止) も都度修正済み。
+
+---
+
+## 洗い出し (ネットで新しい項目)
+
+各項目に Discord / DB / コードの根拠を併記。末尾の「起票」は Plane KAT Issue。
+
+### 1. 試合日程調整 (スケジューラ) — 運営最大の紛争源
+- **生声**: root 運営「スケジュール今回めちゃ揉める…スケジューラの作り方がわからん…対策考える」。AM/PM・12h/24h 取り違えで実紛争、無反応チームを運営が手動仲裁、口論の仲裁まで発生。
+- **DB**: 184 試合中 日付 21 / 時刻 20 しか入力されていない (room_id・judge_name はほぼ全件)。TZ カラム無し。
+- **公開**: 「異なる国で TZ 把握に 2 日かかる、事前開示したい」。
+- → **起票: feature** (TZ 対応の日程調整フロー)
+
+### 2. ルーム貸し & ジャッジ手配 — 運営の最大の時間泥棒
+- **生声**: help-judge はほぼ全部これ。「今日ルーム 4 つ欲しい」「9 時 12 時いける人？」を 24h・週 12 試合を実質 4 人で回す。Room ID を手で配布。
+- アプリは room_id / judge_name を事後記録するのみ。空き状況・割当の支援は重く、アプリの守備範囲が曖昧。
+- → **未起票** (要検討。現状アプリ範囲外、Discord 運用で回している)
+
+### 3. 失格・不戦勝・no-game の結果処理が手作業
+- **生声**: 未登録 MD ID 出場 → 失格でスコアを手計算で再調整。no-game 持ち越しも発生。
+- **DB**: `match_results.decision_type` 全 183 = normal、`rounds.ended_by` 全 normal (失格/不戦勝/no-game が一切記録されていない)。
+- **公開**: judge「未登録 ID で出場した例があるので MDID を必ず出して」。
+- → **起票: feature** (DQ/不戦勝/no-game 処理 + 登録 ID↔出場 ID バリデーション)
+
+### 4. 結果カードを手で Discord に貼っている (自動化 ROI 最大)
+- **DB**: `exports.match_result_card` generated **183** (≒ confirmed 181)。
+- **Discord**: 試合結果 ch に **184 画像 / 3 投稿者** (実質 1 人が ~140 枚)。
+- → アプリが全試合分のカードを生成済みなのに人力ポスト。webhook 自動投稿 / 週一括出力で ~180 手作業が消える。
+- → **起票: enhancement**
+
+### 5. ロスター: 削除が残らない・複数 ID の置き場が無い・セルフ申請が無い
+- **DB**: participants 541 全 active (withdrawn 0)。`member_id` は 1 人 1 カラムだが規定は最大 3 ID。533/541 が期中 (week1 以降) 追加。
+- **Discord**: メンバー変更 ch 132 件 / 53 人を自由文で運営に投げ → 手転記。「add ID to 既存選手」頻出 (2 個目 ID の行き場が無い証拠)、`@運営 staff` の催促のみの行が多数。
+- → **起票: feature** (セルフ申請 + 複数 MD ID + 脱退状態管理)
+
+### 6. 参加者向け公開ページが無い (= 結果が見れない / 英訳要望の真因)
+- **コード**: standings / matches / phases は全て organizer 認証背後 (`require_authentication`)。公開 slug / token 無し。
+- **コード**: locale は ja↔en 切替が**既に実装済み** (available_locales [ja,en]、切替 UI あり) だが、認証背後なので国際参加者に届かない。
+- **公開**: JP/EN 両方「結果 (スコアシート) が見れない / 全部出る？」「stats を英訳して」。
+- → 公開ページを作れば「結果が見れない」も「英訳して」も同時に解ける (en 対応は流用)。
+- → **起票: feature**
+
+### 7. 結果入力フローの改善 (運営が 5/17 に直接要望)
+- **生声**: オーダー選手を結果入力に手再入力 / 結果入力画面から各チーム管理へ遷移できない (iPhone で詰まる) / **複数人同時編集不可** (一人が下書き化すると他ジャッジが触れない、並列 12 試合と相性最悪)。
+- → **起票: enhancement × 2** (導線改善 / 複数人同時編集)
+
+---
+
+## 起票一覧 (Plane KAT)
+
+1. (feature) TZ 対応の試合日程調整フロー — **KAT-25**
+2. (feature) 参加者向け公開ページ (順位・結果・日程) — **KAT-26**
+3. (feature) ロスター変更のセルフ申請フロー — **KAT-27**
+4. (feature) 失格・不戦勝・no-game の結果処理 + ID バリデーション — **KAT-28**
+5. (enhancement) 結果カードの Discord 自動投稿 — **KAT-29**
+6. (enhancement) 結果入力フローの導線改善 — **KAT-30**
+7. (enhancement) 結果入力の複数人同時編集対応 — **KAT-31**
+
+未起票: ルーム貸し & ジャッジ手配支援 (アプリ範囲が曖昧、要検討)。
+
+## データ出典
+
+- Discord エクスポート: `~/wmgp-export/*.json` (個人参照、git 管理外)、抽出テキスト `~/wmgp-export/extracted/`
+- 本番 snapshot 集計: staging DB read-only (本ドキュメント作成時点)


### PR DESCRIPTION
## 昇格内容 (staging→main)
- KAT-24 feat: スコアシート(結果カード)にチームアイコンを表示
- KAT-32 enhance: チーム一覧・詳細にチームアイコンを表示
- KAT-33 fix: 結果カードのキャッシュにチームアイコン変更を反映
- KAT-34 docs: Active Storage 永続化を deployment-environments に追記
- docs: WMGP s8 運営・アプリ困りごと洗い出しレポート

## 検証
- staging(本番snapshot)で実機確認済み: 62チームのアイコン取り込み → 結果カード/チーム一覧/詳細に表示、コンテナ再作成耐性(volume)も確認。
- マイグレーション無し (has_one_attached は既存 Active Storage テーブル利用)。
- bin/rails test 77 runs 0 failures。

## merge 時の手順 (本番・WMGP の試合が動いてない時間帯に)
1. merge 前に /opt/katorin2/docker-compose.yml へ storage volume (katorin2_storage) 追加 — KAT-34 本番分。
2. PR を merge → 本番デプロイ自動 (volume 込みで再作成、末尾で数秒リスタート)。
3. 本番 DB へ 62 アイコン取り込み (volume 後なので以後消えない)。

本番 DB は事前バックアップ済み (pg_dump: VPS /tmp + Mac)。