### PR TITLE
KAT-11 refactor: Core 層から "wmgp" 直書きを除去し WMGP module へ集約

### DIFF
--- a/apps/ledger/app/leagues/wmgp/league_module.rb
+++ b/apps/ledger/app/leagues/wmgp/league_module.rb
@@ -1,9 +1,14 @@
 module Wmgp
   class LeagueModule < ::RuleModules::Base
     KEY = "wmgp".freeze
+    DISPLAY_NAME = { ja: "WMGP台帳", en: "WMGP Ledger" }.freeze
 
     def key
       KEY
+    end
+
+    def display_name(locale = I18n.locale)
+      DISPLAY_NAME.fetch(locale.to_sym) { DISPLAY_NAME.fetch(:en) }
     end
 
     def rules

--- a/apps/ledger/app/models/organizer_account.rb
+++ b/apps/ledger/app/models/organizer_account.rb
@@ -47,7 +47,7 @@ class OrganizerAccount < ApplicationRecord
     definition = RuleSets::Registry.fetch(RuleSets::Registry.default_key)
 
     Array(definition["stages"]).each do |stage|
-      key = "wmgp_#{stage.fetch('key')}"
+      key = "#{definition.fetch('key')}_#{stage.fetch('key')}"
       template = stage_assets.find_or_initialize_by(key:)
       next if template.persisted?
 

--- a/apps/ledger/app/models/phase.rb
+++ b/apps/ledger/app/models/phase.rb
@@ -110,7 +110,7 @@ class Phase < ApplicationRecord
   end
 
   def assign_default_rule_module_key
-    self.rule_module_key = stage_asset&.match_rule_key.presence || stage_asset&.key.presence || "wmgp" if rule_module_key.blank?
+    self.rule_module_key = stage_asset&.match_rule_key.presence || stage_asset&.key.presence || ::RuleSets::Registry.default_key if rule_module_key.blank?
   end
 
   def assign_default_name

--- a/apps/ledger/app/services/match_exports/result_card_renderer.rb
+++ b/apps/ledger/app/services/match_exports/result_card_renderer.rb
@@ -63,7 +63,7 @@ module MatchExports
 
     def result_card_layout
       @result_card_layout ||=
-        ::RuleModules::Registry.fetch(::RuleSets::Registry.default_key)
+        ::RuleModules::Registry.default
           .renderers.match_result_card.new(match)
     end
 

--- a/apps/ledger/app/services/rule_modules/registry.rb
+++ b/apps/ledger/app/services/rule_modules/registry.rb
@@ -11,6 +11,10 @@ module RuleModules
         end
       end
 
+      def default
+        modules.values.first or raise(KeyError, "No rule module registered")
+      end
+
       def keys
         modules.keys
       end

--- a/apps/ledger/app/services/rule_sets/registry.rb
+++ b/apps/ledger/app/services/rule_sets/registry.rb
@@ -4,7 +4,7 @@ module RuleSets
 
     class << self
       def default_key
-        "wmgp"
+        builtin_keys.first
       end
 
       def all(organizer_account: nil)

--- a/apps/ledger/app/services/standings/calculator.rb
+++ b/apps/ledger/app/services/standings/calculator.rb
@@ -22,7 +22,7 @@ module Standings
     private
 
     def resolve_ranking_rule
-      league_module = ::RuleModules::Registry.fetch(::RuleSets::Registry.default_key)
+      league_module = ::RuleModules::Registry.default
       league_module.rules.standings_ranking(@phase.ranking_rule_key)
     end
   end

--- a/apps/ledger/app/services/standings_exports/table_renderer.rb
+++ b/apps/ledger/app/services/standings_exports/table_renderer.rb
@@ -46,7 +46,7 @@ module StandingsExports
 
     def standings_table_layout
       @standings_table_layout ||=
-        ::RuleModules::Registry.fetch(::RuleSets::Registry.default_key)
+        ::RuleModules::Registry.default
           .renderers.standings_table.new(@standings_by_block, @blocks)
     end
 

--- a/apps/ledger/app/views/home/index.html.erb
+++ b/apps/ledger/app/views/home/index.html.erb
@@ -2,7 +2,7 @@
 
 <section class="hero hero--landing">
   <div class="hero-card hero-card--stone">
-    <p class="eyebrow"><%= t("home.eyebrow") %></p>
+    <p class="eyebrow"><%= ::RuleModules::Registry.default.display_name %></p>
     <h1><%= t("home.title") %></h1>
     <p class="lede">
       <%= t("home.lede") %>

--- a/apps/ledger/config/locales/en.yml
+++ b/apps/ledger/config/locales/en.yml
@@ -2,7 +2,6 @@ en:
   app:
     name: Katorin2
     application_name: Ledger
-    ledger_name: WMGP Ledger
   locales:
     ja: Japanese
     en: English
@@ -155,7 +154,6 @@ en:
     errors:
       title: Please review the highlighted fields.
   home:
-    eyebrow: WMGP Ledger
     title: Katorin2
     lede: A ledger for league management, result tracking, and image export while keeping Discord operations unchanged.
     features_title: Ledger

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -2,7 +2,6 @@ ja:
   app:
     name: Katorin2
     application_name: 台帳
-    ledger_name: WMGP台帳
   locales:
     ja: 日本語
     en: English
@@ -155,7 +154,6 @@ ja:
     errors:
       title: 入力内容を確認してください。
   home:
-    eyebrow: WMGP台帳
     title: Katorin2
     lede: Discord の運用はそのままに、リーグ管理、結果整理、画像出力をまとめる運営台帳です。
     features_title: 台帳


### PR DESCRIPTION
## 概要

KAT-11 を本番へ昇格する。Core 層から literal `"wmgp"` を除去し、唯一の WMGP リーグモジュール 1 箇所に集約した refactor（Option A: migration なし）。**振る舞い・画面表示は完全に不変**。

これにより **KAT-6 (Phase 2 PoC 節目) の残タスクが完了**し Phase 2 PoC 完走。

## 主な変更

- `RuleModules::Registry.default` 追加 → 3 junction (calculator / result_card_renderer / table_renderer) が `fetch(default_key)` から `.default` へ
- `RuleSets::Registry.default_key` を literal から `builtin_keys.first` 導出へ（単一 ruleset 前提）
- `phase.rb` フォールバック・`organizer_account.rb` prefix を literal から定数/定義由来へ
- locale: brand 文字列を `Wmgp::LeagueModule#display_name` へ移動、home eyebrow は module 由来に。dead な `app.ledger_name` 削除（表示は "WMGP台帳"/"WMGP Ledger" のまま）

## 検証

- `bin/rails test` (apps/ledger): 96 runs, 1077 assertions, 0 failures, 0 errors
- `grep -ri wmgp`（app/services・app/models・app/controllers・config/locales）= ヒット0。literal は `app/leagues/wmgp/**`・`config/rulesets/wmgp.json`・initializer のみ（受入条件で許容）

## ⚠️ commit リストの注意

過去 PR の rebase merge 由来で commit リストに SHA 違いの既反映分が並ぶが、**net ファイル差分は KAT-11 の 11 ファイルのみ**。
