### PR TITLE
feat: ロスター変更セルフ申請 (KAT-27) の portal + 審査 UI

### DIFF
--- a/apps/ledger/app/controllers/roster_change_requests_controller.rb
+++ b/apps/ledger/app/controllers/roster_change_requests_controller.rb
@@ -1,0 +1,79 @@
+class RosterChangeRequestsController < ApplicationController
+  before_action :admin_or_above!
+  before_action :set_team
+  before_action :set_roster_change_request, only: %i[show approve reject]
+
+  def index
+    @requests = @team.roster_change_requests.recent_first
+  end
+
+  def show
+  end
+
+  def approve
+    unless @roster_change_request.pending?
+      return redirect_to league_team_roster_change_request_path(league_id: @league, team_id: @team, id: @roster_change_request),
+        alert: t("flash.roster_change_requests.already_reviewed")
+    end
+
+    ActiveRecord::Base.transaction do
+      apply_roster_change_request!(@roster_change_request)
+      @roster_change_request.update!(
+        status: "approved",
+        reviewed_by: current_organizer_member,
+        reviewed_at: Time.current,
+        organizer_note: params[:organizer_note]
+      )
+    end
+
+    redirect_to league_team_roster_change_requests_path(league_id: @league, team_id: @team),
+      notice: t("flash.roster_change_requests.approved")
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to league_team_roster_change_request_path(league_id: @league, team_id: @team, id: @roster_change_request),
+      alert: t("flash.roster_change_requests.approve_failed", errors: e.record.errors.full_messages.to_sentence)
+  end
+
+  def reject
+    unless @roster_change_request.pending?
+      return redirect_to league_team_roster_change_request_path(league_id: @league, team_id: @team, id: @roster_change_request),
+        alert: t("flash.roster_change_requests.already_reviewed")
+    end
+
+    @roster_change_request.update!(
+      status: "rejected",
+      reviewed_by: current_organizer_member,
+      reviewed_at: Time.current,
+      organizer_note: params[:organizer_note]
+    )
+
+    redirect_to league_team_roster_change_requests_path(league_id: @league, team_id: @team),
+      notice: t("flash.roster_change_requests.rejected")
+  end
+
+  private
+
+  def set_team
+    @league = current_organizer_account.leagues.find(params[:league_id])
+    @team = @league.teams.find(params[:team_id])
+  end
+
+  def set_roster_change_request
+    @roster_change_request = @team.roster_change_requests.find(params[:id])
+  end
+
+  def apply_roster_change_request!(request)
+    case request.kind
+    when "add"
+      @team.participants.create!(
+        league: @team.league,
+        display_name: request.proposed_display_name,
+        member_ids: request.proposed_member_ids,
+        status: "active"
+      )
+    when "remove"
+      request.target_participant.update!(status: "withdrawn")
+    when "update_md_id"
+      request.target_participant.update!(member_ids: request.proposed_member_ids)
+    end
+  end
+end

--- a/apps/ledger/app/controllers/team_roster_change_portal_controller.rb
+++ b/apps/ledger/app/controllers/team_roster_change_portal_controller.rb
@@ -1,0 +1,55 @@
+class TeamRosterChangePortalController < ApplicationController
+  allow_unauthenticated_access only: %i[show create_request]
+  skip_before_action :require_member_selection, raise: false
+  skip_before_action :require_organizer_setup, raise: false
+
+  before_action :set_team_from_token
+
+  def show
+    @roster_change_request ||= @team.roster_change_requests.new
+    load_show_collections
+  end
+
+  def create_request
+    @roster_change_request = @team.roster_change_requests.new(request_params)
+
+    if @roster_change_request.save
+      redirect_to team_roster_change_portal_path(token: @team.roster_change_token),
+        notice: t("flash.team_roster_change_portal.request_created")
+    else
+      load_show_collections
+      render :show, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_team_from_token
+    token = params[:token].to_s
+    @team = Team.find_by(roster_change_token: token) if token.present?
+    head :not_found unless @team
+  end
+
+  def load_show_collections
+    @participants = @team.participants.order(:position)
+    @active_participants = @participants.reject { |participant| participant.status == "withdrawn" }
+    @requests = @team.roster_change_requests.recent_first
+  end
+
+  def request_params
+    attrs = params.require(:roster_change_request).permit(
+      :kind,
+      :submitter_display_name,
+      :target_participant_id,
+      :proposed_display_name,
+      :note,
+      proposed_member_ids: []
+    )
+
+    if attrs.key?(:proposed_member_ids)
+      attrs[:proposed_member_ids] = Array(attrs[:proposed_member_ids]).map { |value| value.to_s.strip }.reject(&:blank?)
+    end
+
+    attrs
+  end
+end

--- a/apps/ledger/app/controllers/team_roster_change_tokens_controller.rb
+++ b/apps/ledger/app/controllers/team_roster_change_tokens_controller.rb
@@ -1,0 +1,23 @@
+class TeamRosterChangeTokensController < ApplicationController
+  before_action :admin_or_above!
+  before_action :set_team
+
+  def create
+    @team.regenerate_roster_change_token!
+    redirect_to league_team_path(@team.league, @team),
+      notice: t("flash.teams.roster_change_token.created")
+  end
+
+  def destroy
+    @team.revoke_roster_change_token!
+    redirect_to league_team_path(@team.league, @team),
+      notice: t("flash.teams.roster_change_token.revoked")
+  end
+
+  private
+
+  def set_team
+    league = current_organizer_account.leagues.find(params[:league_id])
+    @team = league.teams.find(params[:team_id])
+  end
+end

--- a/apps/ledger/app/helpers/application_helper.rb
+++ b/apps/ledger/app/helpers/application_helper.rb
@@ -59,6 +59,21 @@ module ApplicationHelper
     status_badge(translated_enum("enums.match.status", match.status), tone)
   end
 
+  def roster_change_request_status_badge(request)
+    return if request.blank?
+
+    tone = case request.status
+           when "approved"
+             "success"
+           when "rejected"
+             "danger"
+           else
+             "warning"
+           end
+
+    status_badge(translated_enum("enums.roster_change_request.status", request.status), tone)
+  end
+
   def enum_options(scope, values)
     values.map { |value| [translated_enum(scope, value), value] }
   end

--- a/apps/ledger/app/models/roster_change_request.rb
+++ b/apps/ledger/app/models/roster_change_request.rb
@@ -1,0 +1,64 @@
+class RosterChangeRequest < ApplicationRecord
+  KINDS = {
+    add: "add",
+    remove: "remove",
+    update_md_id: "update_md_id",
+  }.freeze
+
+  STATUSES = {
+    pending: "pending",
+    approved: "approved",
+    rejected: "rejected",
+  }.freeze
+
+  belongs_to :team
+  belongs_to :target_participant, class_name: "Participant", optional: true
+  belongs_to :reviewed_by, class_name: "OrganizerMember", optional: true
+
+  enum :kind, KINDS, validate: true
+  enum :status, STATUSES, validate: true
+
+  validates :submitter_display_name, presence: true
+  validate :target_participant_required_for_remove_and_update
+  validate :target_participant_belongs_to_team
+  validate :proposed_payload_present_when_required
+  validate :proposed_member_ids_within_limit
+
+  scope :active, -> { where(status: %w[pending approved]) }
+  scope :recent_first, -> { order(created_at: :desc) }
+
+  def reviewed?
+    status != "pending"
+  end
+
+  private
+
+  def target_participant_required_for_remove_and_update
+    return unless %w[remove update_md_id].include?(kind)
+    errors.add(:target_participant_id, :blank) if target_participant_id.blank?
+  end
+
+  def target_participant_belongs_to_team
+    return if target_participant.blank? || team.blank?
+    return if target_participant.team_id == team_id
+
+    errors.add(:target_participant_id, :not_in_team)
+  end
+
+  def proposed_payload_present_when_required
+    case kind
+    when "add"
+      errors.add(:proposed_display_name, :blank) if proposed_display_name.blank?
+    when "update_md_id"
+      errors.add(:proposed_member_ids, :blank) if Array(proposed_member_ids).reject(&:blank?).empty?
+    end
+  end
+
+  def proposed_member_ids_within_limit
+    ids = Array(proposed_member_ids).reject(&:blank?)
+    return if ids.empty?
+    return if ids.size <= Participant::MAX_MEMBER_IDS
+
+    errors.add(:proposed_member_ids, :too_many, count: Participant::MAX_MEMBER_IDS)
+  end
+end

--- a/apps/ledger/app/models/team.rb
+++ b/apps/ledger/app/models/team.rb
@@ -16,6 +16,7 @@ class Team < ApplicationRecord
     class_name: "MatchScheduleCandidate",
     foreign_key: :submitter_team_id,
     dependent: :destroy
+  has_many :roster_change_requests, dependent: :destroy
 
   before_validation :assign_name
   before_validation :assign_short_name
@@ -23,6 +24,7 @@ class Team < ApplicationRecord
   validates :name, :display_name, presence: true
   validates :name, uniqueness: { scope: :league_id }
   validates :schedule_token, uniqueness: true, allow_nil: true
+  validates :roster_change_token, uniqueness: true, allow_nil: true
   validates :drop_kind, inclusion: { in: DROP_KINDS.values }, allow_nil: true
 
   def dropped?
@@ -38,6 +40,17 @@ class Team < ApplicationRecord
 
   def revoke_schedule_token!
     update!(schedule_token: nil, schedule_token_generated_at: nil)
+  end
+
+  def regenerate_roster_change_token!
+    update!(
+      roster_change_token: SecureRandom.urlsafe_base64(24),
+      roster_change_token_generated_at: Time.current
+    )
+  end
+
+  def revoke_roster_change_token!
+    update!(roster_change_token: nil, roster_change_token_generated_at: nil)
   end
 
   # 自 team が関わるすべての match (home/away 問わず)。 公開 portal の表示用。

--- a/apps/ledger/app/views/roster_change_requests/index.html.erb
+++ b/apps/ledger/app/views/roster_change_requests/index.html.erb
@@ -1,0 +1,65 @@
+<% page_title t("roster_change_requests.title_index", team: @team.display_name) %>
+<% set_breadcrumbs([
+  breadcrumb_item(t("nav.home"), dashboard_path),
+  breadcrumb_item(t("leagues.title_index"), leagues_path),
+  breadcrumb_item(@league.name, league_path(id: @league)),
+  breadcrumb_item(t("teams.eyebrow"), league_teams_path(league_id: @league)),
+  breadcrumb_item(@team.display_name, league_team_path(league_id: @league, id: @team)),
+  breadcrumb_item(t("roster_change_requests.eyebrow"))
+]) %>
+
+<section class="page-header">
+  <div>
+    <p class="eyebrow"><%= t("roster_change_requests.eyebrow") %></p>
+    <h1><%= t("roster_change_requests.title_index", team: @team.display_name) %></h1>
+  </div>
+  <div class="page-actions">
+    <%= link_to t("actions.back"), league_team_path(league_id: @league, id: @team), class: "button" %>
+  </div>
+</section>
+
+<% if @requests.empty? %>
+  <p class="empty-copy"><%= t("roster_change_requests.empty") %></p>
+<% else %>
+  <% pending_requests, reviewed_requests = @requests.partition(&:pending?) %>
+
+  <section class="dashboard-grid">
+    <article class="panel">
+      <h2><%= t("roster_change_requests.sections.pending") %></h2>
+      <% if pending_requests.empty? %>
+        <p class="empty-copy"><%= t("roster_change_requests.empty") %></p>
+      <% else %>
+        <ul class="compact-list">
+          <% pending_requests.each do |request| %>
+            <li>
+              <strong><%= translated_enum("enums.roster_change_request.kind", request.kind) %></strong>
+              <%= roster_change_request_status_badge(request) %>
+              <span class="muted">/ <%= request.submitter_display_name %></span>
+              <%= link_to t("roster_change_requests.actions.view"),
+                league_team_roster_change_request_path(league_id: @league, team_id: @team, id: request), class: "inline-link" %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    </article>
+
+    <article class="panel">
+      <h2><%= t("roster_change_requests.sections.reviewed") %></h2>
+      <% if reviewed_requests.empty? %>
+        <p class="empty-copy"><%= t("roster_change_requests.empty") %></p>
+      <% else %>
+        <ul class="compact-list">
+          <% reviewed_requests.each do |request| %>
+            <li>
+              <strong><%= translated_enum("enums.roster_change_request.kind", request.kind) %></strong>
+              <%= roster_change_request_status_badge(request) %>
+              <span class="muted">/ <%= request.submitter_display_name %></span>
+              <%= link_to t("roster_change_requests.actions.view"),
+                league_team_roster_change_request_path(league_id: @league, team_id: @team, id: request), class: "inline-link" %>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+    </article>
+  </section>
+<% end %>

--- a/apps/ledger/app/views/roster_change_requests/show.html.erb
+++ b/apps/ledger/app/views/roster_change_requests/show.html.erb
@@ -1,0 +1,90 @@
+<% page_title t("roster_change_requests.title_show") %>
+<% set_breadcrumbs([
+  breadcrumb_item(t("nav.home"), dashboard_path),
+  breadcrumb_item(t("leagues.title_index"), leagues_path),
+  breadcrumb_item(@league.name, league_path(id: @league)),
+  breadcrumb_item(t("teams.eyebrow"), league_teams_path(league_id: @league)),
+  breadcrumb_item(@team.display_name, league_team_path(league_id: @league, id: @team)),
+  breadcrumb_item(t("roster_change_requests.eyebrow"), league_team_roster_change_requests_path(league_id: @league, team_id: @team)),
+  breadcrumb_item(t("roster_change_requests.title_show"))
+]) %>
+
+<section class="page-header">
+  <div>
+    <p class="eyebrow"><%= t("roster_change_requests.eyebrow") %></p>
+    <h1><%= translated_enum("enums.roster_change_request.kind", @roster_change_request.kind) %></h1>
+    <p class="muted"><%= roster_change_request_status_badge(@roster_change_request) %></p>
+  </div>
+  <div class="page-actions">
+    <%= link_to t("actions.back"), league_team_roster_change_requests_path(league_id: @league, team_id: @team), class: "button" %>
+  </div>
+</section>
+
+<article class="panel">
+  <div class="kv-list">
+    <div>
+      <span><%= t("roster_change_requests.fields.submitter_display_name") %></span>
+      <strong><%= @roster_change_request.submitter_display_name %></strong>
+    </div>
+    <div>
+      <span><%= t("roster_change_requests.fields.target_participant") %></span>
+      <strong><%= @roster_change_request.target_participant&.display_name || t("roster_change_requests.empty_target") %></strong>
+    </div>
+    <div>
+      <span><%= t("roster_change_requests.fields.proposed_display_name") %></span>
+      <strong><%= @roster_change_request.proposed_display_name.presence || t("labels.none") %></strong>
+    </div>
+    <div>
+      <span><%= t("roster_change_requests.fields.proposed_member_ids") %></span>
+      <strong><%= Array(@roster_change_request.proposed_member_ids).reject(&:blank?).presence&.join(", ") || t("labels.none") %></strong>
+    </div>
+    <div>
+      <span><%= t("roster_change_requests.fields.note") %></span>
+      <strong><%= @roster_change_request.note.presence || t("labels.none") %></strong>
+    </div>
+    <% if @roster_change_request.reviewed? %>
+      <div>
+        <span><%= t("roster_change_requests.fields.organizer_note") %></span>
+        <strong><%= @roster_change_request.organizer_note.presence || t("labels.none") %></strong>
+      </div>
+      <div>
+        <span><%= t("roster_change_requests.fields.reviewed_by") %></span>
+        <strong><%= @roster_change_request.reviewed_by&.display_name || t("labels.none") %></strong>
+      </div>
+      <div>
+        <span><%= t("roster_change_requests.fields.reviewed_at") %></span>
+        <strong><%= l(@roster_change_request.reviewed_at.in_time_zone("Asia/Tokyo"), format: :long) if @roster_change_request.reviewed_at %></strong>
+      </div>
+    <% end %>
+  </div>
+</article>
+
+<% if @roster_change_request.pending? %>
+  <section class="dashboard-grid">
+    <article class="panel">
+      <h2><%= t("roster_change_requests.actions.approve") %></h2>
+      <%= form_with url: approve_league_team_roster_change_request_path(league_id: @league, team_id: @team, id: @roster_change_request),
+            scope: nil, method: :post, class: "stack" do |form| %>
+        <div class="field">
+          <%= form.label :organizer_note, t("roster_change_requests.actions.organizer_note_label") %>
+          <%= form.text_area :organizer_note, rows: 2 %>
+        </div>
+        <%= form.submit t("roster_change_requests.actions.approve"), class: "button button--primary",
+              data: { turbo_confirm: t("roster_change_requests.actions.approve_confirm") } %>
+      <% end %>
+    </article>
+
+    <article class="panel">
+      <h2><%= t("roster_change_requests.actions.reject") %></h2>
+      <%= form_with url: reject_league_team_roster_change_request_path(league_id: @league, team_id: @team, id: @roster_change_request),
+            scope: nil, method: :post, class: "stack" do |form| %>
+        <div class="field">
+          <%= form.label :organizer_note, t("roster_change_requests.actions.organizer_note_label") %>
+          <%= form.text_area :organizer_note, rows: 2 %>
+        </div>
+        <%= form.submit t("roster_change_requests.actions.reject"), class: "button button--danger",
+              data: { turbo_confirm: t("roster_change_requests.actions.reject_confirm") } %>
+      <% end %>
+    </article>
+  </section>
+<% end %>

--- a/apps/ledger/app/views/team_roster_change_portal/show.html.erb
+++ b/apps/ledger/app/views/team_roster_change_portal/show.html.erb
@@ -1,0 +1,107 @@
+<% page_title t("team_roster_change_portal.show.title", team: @team.display_name) %>
+
+<section class="page-header">
+  <div>
+    <p class="eyebrow"><%= t("team_roster_change_portal.eyebrow") %></p>
+    <h1><%= t("team_roster_change_portal.show.title", team: @team.display_name) %></h1>
+    <p class="muted"><%= t("team_roster_change_portal.show.lede", league: @team.league.name) %></p>
+  </div>
+</section>
+
+<article class="panel">
+  <h2><%= t("team_roster_change_portal.show.roster_heading") %></h2>
+  <% if @participants.empty? %>
+    <p class="empty-copy"><%= t("team_roster_change_portal.show.roster_empty") %></p>
+  <% else %>
+    <ul class="compact-list">
+      <% @participants.each do |participant| %>
+        <li>
+          <strong><%= participant.display_name %></strong>
+          <span class="muted">
+            / <%= t("labels.member_id") %>: <%= Array(participant.member_ids).reject(&:blank?).presence&.join(", ") || t("labels.none") %>
+            / <%= translated_enum("enums.participant.status", participant.status) %>
+          </span>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</article>
+
+<article class="panel">
+  <h2><%= t("team_roster_change_portal.show.request_heading") %></h2>
+  <%= render "shared/errors", record: @roster_change_request %>
+
+  <%= form_with model: @roster_change_request,
+        url: team_roster_change_portal_create_request_path(token: @team.roster_change_token),
+        class: "stack" do |form| %>
+    <div class="field">
+      <%= form.label :kind, t("team_roster_change_portal.form.kind") %>
+      <%= form.select :kind, enum_options("enums.roster_change_request.kind", RosterChangeRequest::KINDS.values) %>
+    </div>
+
+    <div class="field">
+      <%= form.label :submitter_display_name, t("team_roster_change_portal.form.submitter_display_name") %>
+      <%= form.text_field :submitter_display_name, required: true %>
+    </div>
+
+    <div class="field">
+      <%= form.label :target_participant_id, t("team_roster_change_portal.form.target_participant") %>
+      <%= form.collection_select :target_participant_id, @active_participants, :id, :display_name,
+            include_blank: t("team_roster_change_portal.form.target_participant_prompt") %>
+    </div>
+
+    <div class="field">
+      <%= form.label :proposed_display_name, t("team_roster_change_portal.form.proposed_display_name") %>
+      <%= form.text_field :proposed_display_name %>
+    </div>
+
+    <% proposed_member_ids = Array(@roster_change_request.proposed_member_ids).reject(&:blank?) %>
+    <div class="field">
+      <%= form.label :proposed_member_ids, t("team_roster_change_portal.form.proposed_member_ids") %>
+      <% Participant::MAX_MEMBER_IDS.times do |index| %>
+        <%= text_field_tag "roster_change_request[proposed_member_ids][]", proposed_member_ids[index],
+              id: "roster_change_request_proposed_member_ids_#{index}",
+              aria: { label: t("team_roster_change_portal.form.proposed_member_ids_nth", number: index + 1) } %>
+      <% end %>
+    </div>
+
+    <div class="field">
+      <%= form.label :note, t("team_roster_change_portal.form.note") %>
+      <%= form.text_area :note, rows: 2 %>
+    </div>
+
+    <%= form.submit t("team_roster_change_portal.form.submit"), class: "button button--primary" %>
+  <% end %>
+</article>
+
+<article class="panel">
+  <h2><%= t("team_roster_change_portal.show.history_heading") %></h2>
+  <% if @requests.empty? %>
+    <p class="empty-copy"><%= t("team_roster_change_portal.show.history_empty") %></p>
+  <% else %>
+    <ul class="compact-list">
+      <% @requests.each do |request| %>
+        <li>
+          <strong><%= translated_enum("enums.roster_change_request.kind", request.kind) %></strong>
+          <%= roster_change_request_status_badge(request) %>
+          <span class="muted">/ <%= t("team_roster_change_portal.show.submitted_by", submitter: request.submitter_display_name) %></span>
+          <% if request.target_participant.present? %>
+            <p class="muted"><%= t("team_roster_change_portal.show.target_participant_label", participant: request.target_participant.display_name) %></p>
+          <% end %>
+          <% if request.proposed_display_name.present? %>
+            <p class="muted"><%= t("team_roster_change_portal.show.proposed_display_name_label", name: request.proposed_display_name) %></p>
+          <% end %>
+          <% if Array(request.proposed_member_ids).reject(&:blank?).any? %>
+            <p class="muted"><%= t("team_roster_change_portal.show.proposed_member_ids_label", member_ids: request.proposed_member_ids.join(", ")) %></p>
+          <% end %>
+          <% if request.note.present? %>
+            <p class="muted"><%= request.note %></p>
+          <% end %>
+          <% if request.reviewed? %>
+            <p class="muted"><%= t("team_roster_change_portal.show.reviewed_note", note: request.organizer_note.presence || t("labels.none")) %></p>
+          <% end %>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
+</article>

--- a/apps/ledger/app/views/teams/show.html.erb
+++ b/apps/ledger/app/views/teams/show.html.erb
@@ -108,3 +108,48 @@
     </article>
   </section>
 <% end %>
+
+<% if can_manage? %>
+  <section class="dashboard-grid">
+    <article class="panel">
+      <h2><%= t("teams.roster_change_token.title") %></h2>
+      <p class="muted"><%= t("teams.roster_change_token.lede") %></p>
+      <% if @team.roster_change_token.present? %>
+        <div class="kv-list">
+          <div>
+            <span><%= t("teams.roster_change_token.share_url") %></span>
+            <strong>
+              <code><%= team_roster_change_portal_url(token: @team.roster_change_token, locale: nil, host: request.host_with_port, protocol: request.protocol) %></code>
+            </strong>
+          </div>
+          <div>
+            <span><%= t("teams.roster_change_token.generated_at") %></span>
+            <strong><%= l(@team.roster_change_token_generated_at.in_time_zone("Asia/Tokyo"), format: :long) if @team.roster_change_token_generated_at %></strong>
+          </div>
+        </div>
+        <div class="page-actions">
+          <%= button_to t("teams.roster_change_token.regenerate"),
+            league_team_roster_change_token_path(league_id: @league, team_id: @team),
+            method: :post,
+            class: "button",
+            form: { data: { turbo_confirm: t("teams.roster_change_token.regenerate_confirm") } } %>
+          <%= button_to t("teams.roster_change_token.revoke"),
+            league_team_roster_change_token_path(league_id: @league, team_id: @team),
+            method: :delete,
+            class: "button button--danger",
+            form: { data: { turbo_confirm: t("teams.roster_change_token.revoke_confirm") } } %>
+        </div>
+      <% else %>
+        <p class="muted"><%= t("teams.roster_change_token.empty") %></p>
+        <%= button_to t("teams.roster_change_token.generate"),
+          league_team_roster_change_token_path(league_id: @league, team_id: @team),
+          method: :post,
+          class: "button button--primary" %>
+      <% end %>
+      <div class="page-actions">
+        <%= link_to t("teams.roster_change_token.requests_link", count: @team.roster_change_requests.pending.count),
+          league_team_roster_change_requests_path(league_id: @league, team_id: @team), class: "button" %>
+      </div>
+    </article>
+  </section>
+<% end %>

--- a/apps/ledger/config/locales/en.yml
+++ b/apps/ledger/config/locales/en.yml
@@ -101,11 +101,22 @@ en:
       schedule_token:
         created: Schedule token issued. Share the URL with the team.
         revoked: Schedule token revoked.
+      roster_change_token:
+        created: Roster change token issued. Share the URL with the team.
+        revoked: Roster change token revoked.
     team_schedule_portal:
       candidate_created: Candidate slot submitted.
       candidate_withdrawn: Candidate slot withdrawn.
       cannot_withdraw_other_team: You cannot withdraw another team's candidate.
       cannot_withdraw_accepted: Confirmed candidates cannot be withdrawn.
+    team_roster_change_portal:
+      request_created: Request submitted. Please wait for organizer review.
+      request_invalid: Please review the request details.
+    roster_change_requests:
+      approved: Request approved and applied to the roster.
+      approve_failed: "Failed to apply the request: %{errors}"
+      rejected: Request rejected.
+      already_reviewed: This request has already been reviewed.
     match_schedule_candidates:
       accepted: Candidate confirmed and written back to match schedule.
       delete_blocked: This team cannot be deleted because it is already used in matches. Use the dropped status after publishing.
@@ -285,6 +296,18 @@ en:
       regenerate_confirm: The previous URL will stop working. Continue?
       revoke: Revoke
       revoke_confirm: Revoking the token disables the shared URL. Continue?
+    roster_change_token:
+      title: Roster change request token
+      lede: Issue a shareable URL for this team. Holders can request roster changes without authentication.
+      share_url: Share URL
+      generated_at: Generated at
+      empty: No token issued yet.
+      generate: Issue token
+      regenerate: Regenerate
+      regenerate_confirm: The previous URL will stop working. Continue?
+      revoke: Revoke
+      revoke_confirm: Revoking the token disables the shared URL. Continue?
+      requests_link: "View requests (%{count} pending)"
   team_schedule_portal:
     eyebrow: Schedule submission
     show:
@@ -304,6 +327,56 @@ en:
       submitter_tz: Timezone
       notes: Notes (optional)
       submit: Submit candidate
+  team_roster_change_portal:
+    eyebrow: Roster change request
+    show:
+      title: "%{team} roster change requests"
+      lede: "Current roster for %{league}. Use the form below to request a change."
+      roster_heading: Current roster
+      roster_empty: No members registered yet.
+      request_heading: Submit a change
+      history_heading: Request history
+      history_empty: No requests submitted yet.
+      submitted_by: Submitted by %{submitter}
+      target_participant_label: "Target member: %{participant}"
+      proposed_display_name_label: "New member name: %{name}"
+      proposed_member_ids_label: "Member IDs: %{member_ids}"
+      reviewed_note: "Organizer note: %{note}"
+    form:
+      kind: Request type
+      submitter_display_name: Submitter name
+      target_participant: "Target member (for remove / update member ID)"
+      target_participant_prompt: Select a member
+      proposed_display_name: "New member name (for add)"
+      proposed_member_ids: "Member IDs (up to 3, for update member ID)"
+      proposed_member_ids_nth: "Member ID %{number}"
+      note: Notes (optional)
+      submit: Submit request
+  roster_change_requests:
+    eyebrow: Roster change requests
+    title_index: "%{team} roster change requests"
+    title_show: Request details
+    empty: No requests yet.
+    empty_target: (no target member)
+    sections:
+      pending: Pending
+      reviewed: Reviewed
+    fields:
+      submitter_display_name: Submitter name
+      target_participant: Target member
+      proposed_display_name: New member name
+      proposed_member_ids: Member IDs
+      note: Notes
+      organizer_note: Organizer note
+      reviewed_by: Reviewed by
+      reviewed_at: Reviewed at
+    actions:
+      view: Details
+      approve: Approve
+      reject: Reject
+      approve_confirm: Approve this request and apply it to the roster?
+      reject_confirm: Reject this request?
+      organizer_note_label: Organizer note (optional)
   participants:
     eyebrow: Members
     title_new: "Add member to %{team}"
@@ -713,6 +786,15 @@ en:
         leader: Leader
         sub_leader: Sub-leader
         member: Member
+    roster_change_request:
+      kind:
+        add: Add
+        remove: Remove
+        update_md_id: Update member ID
+      status:
+        pending: Pending
+        approved: Approved
+        rejected: Rejected
   activerecord:
     models:
       league: League
@@ -721,6 +803,7 @@ en:
       stage_asset: Stage asset
       week: Week
       match: Match
+      roster_change_request: Roster change request
     attributes:
       league:
         name: League name
@@ -786,6 +869,17 @@ en:
         home_game_wins: Home game wins
         away_game_wins: Away game wins
         winner_side: Winner side
+      roster_change_request:
+        kind: Kind
+        status: Status
+        submitter_display_name: Submitter name
+        target_participant_id: Target member
+        proposed_display_name: New member name
+        proposed_member_ids: Member IDs
+        note: Notes
+        organizer_note: Organizer note
+        reviewed_by: Reviewed by
+        reviewed_at: Reviewed at
     errors:
       messages:
         blank: can't be blank.
@@ -807,6 +901,12 @@ en:
             member_ids:
               too_many: allows up to %{count} entries.
               duplicate: "`%{value}` is already used within the same league."
+        roster_change_request:
+          attributes:
+            target_participant_id:
+              not_in_team: must be a member of the same team.
+            proposed_member_ids:
+              too_many: allows up to %{count} entries.
   helpers:
     submit:
       create: "Create %{model}"

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -102,11 +102,22 @@ ja:
       schedule_token:
         created: スケジュール token を発行しました。共有 URL をチームに渡してください。
         revoked: スケジュール token を取消しました。
+      roster_change_token:
+        created: ロスター変更申請 token を発行しました。共有 URL をチームに渡してください。
+        revoked: ロスター変更申請 token を取消しました。
     team_schedule_portal:
       candidate_created: 候補日時を提出しました。
       candidate_withdrawn: 候補日時を取下げました。
       cannot_withdraw_other_team: 他チームの候補は取下げできません。
       cannot_withdraw_accepted: 確定済みの候補は取下げできません。
+    team_roster_change_portal:
+      request_created: 申請を送信しました。運営の確認をお待ちください。
+      request_invalid: 入力内容を確認してください。
+    roster_change_requests:
+      approved: 申請を承認しました。ロスターに反映しました。
+      approve_failed: "申請の反映に失敗しました: %{errors}"
+      rejected: 申請を却下しました。
+      already_reviewed: この申請はすでに審査済みです。
     match_schedule_candidates:
       accepted: 候補日時を確定しました。試合日時に反映しました。
     team_imports:
@@ -285,6 +296,18 @@ ja:
       regenerate_confirm: 古い URL は無効になります。再発行しますか？
       revoke: 取消
       revoke_confirm: token を取消すると共有 URL は無効になります。よろしいですか？
+    roster_change_token:
+      title: ロスター変更申請 token
+      lede: チームに渡す共有 URL を発行します。受け取った人は認証なしでロスター変更を申請できます。
+      share_url: 共有 URL
+      generated_at: 発行日時
+      empty: まだ token は発行されていません。
+      generate: token を発行
+      regenerate: 再発行
+      regenerate_confirm: 古い URL は無効になります。再発行しますか？
+      revoke: 取消
+      revoke_confirm: token を取消すると共有 URL は無効になります。よろしいですか？
+      requests_link: "申請一覧 (未対応 %{count}件)"
   team_schedule_portal:
     eyebrow: スケジュール提出
     show:
@@ -304,6 +327,56 @@ ja:
       submitter_tz: タイムゾーン
       notes: 補足 (任意)
       submit: 候補を提出
+  team_roster_change_portal:
+    eyebrow: ロスター変更申請
+    show:
+      title: "%{team} のロスター変更申請"
+      lede: "%{league} のロスターです。変更が必要な場合は下のフォームから申請してください。"
+      roster_heading: 現在のロスター
+      roster_empty: メンバーがまだ登録されていません。
+      request_heading: 変更を申請する
+      history_heading: 申請履歴
+      history_empty: 申請はまだありません。
+      submitted_by: 申請者 %{submitter}
+      target_participant_label: "対象メンバー: %{participant}"
+      proposed_display_name_label: "新メンバー名: %{name}"
+      proposed_member_ids_label: "MD ID: %{member_ids}"
+      reviewed_note: "運営コメント: %{note}"
+    form:
+      kind: 申請種別
+      submitter_display_name: 申請者名
+      target_participant: "対象メンバー (除外 / MD ID 変更で使用)"
+      target_participant_prompt: メンバーを選択
+      proposed_display_name: "新メンバー名 (追加で使用)"
+      proposed_member_ids: "MD ID（最大3件、MD ID 変更で使用）"
+      proposed_member_ids_nth: "MD ID %{number}"
+      note: 補足 (任意)
+      submit: 申請を送信
+  roster_change_requests:
+    eyebrow: ロスター変更申請
+    title_index: "%{team} のロスター変更申請"
+    title_show: 申請詳細
+    empty: 申請はまだありません。
+    empty_target: (対象メンバーなし)
+    sections:
+      pending: 未対応
+      reviewed: 対応済み
+    fields:
+      submitter_display_name: 申請者名
+      target_participant: 対象メンバー
+      proposed_display_name: 新メンバー名
+      proposed_member_ids: MD ID
+      note: 補足
+      organizer_note: 運営コメント
+      reviewed_by: 対応者
+      reviewed_at: 対応日時
+    actions:
+      view: 詳細
+      approve: 承認
+      reject: 却下
+      approve_confirm: この申請を承認してロスターに反映しますか？
+      reject_confirm: この申請を却下しますか？
+      organizer_note_label: 運営コメント (任意)
   participants:
     eyebrow: メンバー
     title_new: "%{team} にメンバー追加"
@@ -713,6 +786,15 @@ ja:
         leader: リーダー
         sub_leader: サブリーダー
         member: メンバー
+    roster_change_request:
+      kind:
+        add: 追加
+        remove: 除外
+        update_md_id: MD ID 変更
+      status:
+        pending: 未対応
+        approved: 承認
+        rejected: 却下
   activerecord:
     models:
       league: リーグ
@@ -721,6 +803,7 @@ ja:
       stage_asset: ステージアセット
       week: 週
       match: 対戦カード
+      roster_change_request: ロスター変更申請
     attributes:
       league:
         name: リーグ名
@@ -786,6 +869,17 @@ ja:
         home_game_wins: ホームゲーム勝数
         away_game_wins: アウェイゲーム勝数
         winner_side: 勝者サイド
+      roster_change_request:
+        kind: 種別
+        status: 状態
+        submitter_display_name: 申請者名
+        target_participant_id: 対象メンバー
+        proposed_display_name: 新メンバー名
+        proposed_member_ids: MD ID
+        note: 補足
+        organizer_note: 運営コメント
+        reviewed_by: 対応者
+        reviewed_at: 対応日時
     errors:
       messages:
         blank: を入力してください。
@@ -807,6 +901,12 @@ ja:
             member_ids:
               too_many: は最大 %{count} 件までです。
               duplicate: "`%{value}` は同じリーグ内ですでに使われています。"
+        roster_change_request:
+          attributes:
+            target_participant_id:
+              not_in_team: は同じチームのメンバーを選択してください。
+            proposed_member_ids:
+              too_many: は最大 %{count} 件までです。
   helpers:
     submit:
       create: "%{model}を作成"

--- a/apps/ledger/config/routes.rb
+++ b/apps/ledger/config/routes.rb
@@ -43,6 +43,11 @@ Rails.application.routes.draw do
     delete "schedule/:token/matches/:match_id/candidates/:id",
       to: "team_schedule_portal#withdraw_candidate", as: :team_schedule_portal_withdraw_candidate
 
+    # KAT-27: 公開 (認証不要) の roster change portal。 token-based access
+    get "roster/:token", to: "team_roster_change_portal#show", as: :team_roster_change_portal
+    post "roster/:token/requests",
+      to: "team_roster_change_portal#create_request", as: :team_roster_change_portal_create_request
+
     resources :leagues, only: %i[index show new create edit update destroy] do
       resource :team_import, only: %i[new create], controller: "team_imports" do
         get :template
@@ -50,6 +55,13 @@ Rails.application.routes.draw do
       resources :teams, only: %i[index show new create edit update destroy] do
         resources :participants, only: %i[new create edit update destroy]
         resource :schedule_token, only: %i[create destroy], controller: "team_schedule_tokens"
+        resource :roster_change_token, only: %i[create destroy], controller: "team_roster_change_tokens"
+        resources :roster_change_requests, only: %i[index show] do
+          member do
+            post :approve
+            post :reject
+          end
+        end
       end
       resources :phases, only: %i[show new create edit update destroy] do
         member do

--- a/apps/ledger/db/migrate/20260529120000_add_roster_change_token_to_teams.rb
+++ b/apps/ledger/db/migrate/20260529120000_add_roster_change_token_to_teams.rb
@@ -1,0 +1,7 @@
+class AddRosterChangeTokenToTeams < ActiveRecord::Migration[8.1]
+  def change
+    add_column :teams, :roster_change_token, :string
+    add_column :teams, :roster_change_token_generated_at, :datetime
+    add_index :teams, :roster_change_token, unique: true
+  end
+end

--- a/apps/ledger/db/migrate/20260529120001_create_roster_change_requests.rb
+++ b/apps/ledger/db/migrate/20260529120001_create_roster_change_requests.rb
@@ -1,0 +1,27 @@
+class CreateRosterChangeRequests < ActiveRecord::Migration[8.1]
+  def change
+    create_table :roster_change_requests, id: :uuid do |t|
+      t.references :team, type: :uuid, null: false, foreign_key: true, index: true
+      t.string :kind, null: false
+      t.string :status, null: false, default: "pending"
+      t.string :submitter_display_name
+      t.references :target_participant, type: :uuid, foreign_key: { to_table: :participants }, index: true
+      t.string :proposed_display_name
+      t.string :proposed_member_ids, array: true, default: []
+      t.text :note
+      t.string :organizer_note
+      t.references :reviewed_by, type: :uuid, foreign_key: { to_table: :organizer_members }, index: true
+      t.datetime :reviewed_at
+
+      t.timestamps
+    end
+
+    add_index :roster_change_requests, [:team_id, :status]
+    add_check_constraint :roster_change_requests,
+      "kind IN ('add', 'remove', 'update_md_id')",
+      name: "roster_change_requests_kind_inclusion"
+    add_check_constraint :roster_change_requests,
+      "status IN ('pending', 'approved', 'rejected')",
+      name: "roster_change_requests_status_inclusion"
+  end
+end

--- a/apps/ledger/db/schema.rb
+++ b/apps/ledger/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_28_121904) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_29_120001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"
@@ -286,6 +286,28 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_121904) do
     t.index ["stage_asset_id"], name: "index_phases_on_stage_asset_id"
   end
 
+  create_table "roster_change_requests", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "kind", null: false
+    t.text "note"
+    t.string "organizer_note"
+    t.string "proposed_display_name"
+    t.string "proposed_member_ids", default: [], array: true
+    t.datetime "reviewed_at"
+    t.uuid "reviewed_by_id"
+    t.string "status", default: "pending", null: false
+    t.string "submitter_display_name"
+    t.uuid "target_participant_id"
+    t.uuid "team_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["reviewed_by_id"], name: "index_roster_change_requests_on_reviewed_by_id"
+    t.index ["target_participant_id"], name: "index_roster_change_requests_on_target_participant_id"
+    t.index ["team_id", "status"], name: "index_roster_change_requests_on_team_id_and_status"
+    t.index ["team_id"], name: "index_roster_change_requests_on_team_id"
+    t.check_constraint "kind::text = ANY (ARRAY['add'::character varying, 'remove'::character varying, 'update_md_id'::character varying]::text[])", name: "roster_change_requests_kind_inclusion"
+    t.check_constraint "status::text = ANY (ARRAY['pending'::character varying, 'approved'::character varying, 'rejected'::character varying]::text[])", name: "roster_change_requests_status_inclusion"
+  end
+
   create_table "rounds", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "away_team_id"
     t.datetime "created_at", null: false
@@ -337,6 +359,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_121904) do
     t.uuid "league_id", null: false
     t.string "name", null: false
     t.text "notes"
+    t.string "roster_change_token"
+    t.datetime "roster_change_token_generated_at"
     t.string "schedule_token"
     t.datetime "schedule_token_generated_at"
     t.string "short_name"
@@ -345,6 +369,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_121904) do
     t.index ["block_id"], name: "index_teams_on_block_id"
     t.index ["league_id", "name"], name: "index_teams_on_league_id_and_name", unique: true
     t.index ["league_id"], name: "index_teams_on_league_id"
+    t.index ["roster_change_token"], name: "index_teams_on_roster_change_token", unique: true
     t.index ["schedule_token"], name: "index_teams_on_schedule_token", unique: true
     t.check_constraint "drop_kind IS NULL OR (drop_kind::text = ANY (ARRAY['forced'::character varying, 'voluntary'::character varying]::text[]))", name: "teams_drop_kind_inclusion"
   end
@@ -400,6 +425,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_28_121904) do
   add_foreign_key "participants", "teams"
   add_foreign_key "phases", "leagues"
   add_foreign_key "phases", "stage_assets"
+  add_foreign_key "roster_change_requests", "organizer_members", column: "reviewed_by_id"
+  add_foreign_key "roster_change_requests", "participants", column: "target_participant_id"
+  add_foreign_key "roster_change_requests", "teams"
   add_foreign_key "rounds", "matches"
   add_foreign_key "rounds", "teams", column: "away_team_id"
   add_foreign_key "rounds", "teams", column: "home_team_id"

--- a/apps/ledger/test/integration/roster_change_requests_flow_test.rb
+++ b/apps/ledger/test/integration/roster_change_requests_flow_test.rb
@@ -1,0 +1,183 @@
+require "test_helper"
+
+class RosterChangeRequestsFlowTest < ActionDispatch::IntegrationTest
+  setup do
+    @password = "password"
+    @organizer_account = OrganizerAccount.create!(
+      display_name: "Roster Change Flow Organizer",
+      login_id: "roster-change-flow-admin",
+      email: "roster-change-flow-admin@example.com",
+      password: @password
+    )
+    @owner = @organizer_account.organizer_members.create!(
+      display_name: "Owner",
+      role: "owner",
+      active: true,
+      admin_password: "1234"
+    )
+    @staff = @organizer_account.organizer_members.create!(
+      display_name: "Staff",
+      role: "staff",
+      active: true
+    )
+    @league = @organizer_account.leagues.create!(
+      name: "Roster Change Flow League",
+      status: "active",
+      roster_min_members: 4,
+      roster_max_members: 8,
+      lineup_size: 3,
+      substitute_size: 1
+    )
+    @team = @league.teams.create!(display_name: "Roster Change Flow Team")
+    @participant = @team.participants.create!(league: @league, display_name: "Existing Player", member_ids: ["MD-1"])
+  end
+
+  test "owner can approve an add request and it creates a new participant" do
+    login_as!(@organizer_account, password: @password, member: @owner)
+    request = @team.roster_change_requests.create!(
+      kind: "add",
+      submitter_display_name: "Captain",
+      proposed_display_name: "New Recruit",
+      proposed_member_ids: ["MD-200"]
+    )
+
+    assert_difference("Participant.count", 1) do
+      post approve_league_team_roster_change_request_path(locale: :ja, league_id: @league, team_id: @team, id: request),
+        params: { organizer_note: "looks good" }
+    end
+
+    assert_redirected_to league_team_roster_change_requests_path(locale: :ja, league_id: @league, team_id: @team)
+    request.reload
+    assert_equal "approved", request.status
+    assert_equal @owner, request.reviewed_by
+    assert_not_nil request.reviewed_at
+    assert_equal "looks good", request.organizer_note
+
+    new_participant = @team.participants.find_by!(display_name: "New Recruit")
+    assert_equal ["MD-200"], new_participant.member_ids
+    assert_equal "active", new_participant.status
+  end
+
+  test "owner can approve a remove request and it withdraws the participant" do
+    login_as!(@organizer_account, password: @password, member: @owner)
+    request = @team.roster_change_requests.create!(
+      kind: "remove",
+      submitter_display_name: "Captain",
+      target_participant: @participant
+    )
+
+    post approve_league_team_roster_change_request_path(locale: :ja, league_id: @league, team_id: @team, id: request)
+
+    assert_redirected_to league_team_roster_change_requests_path(locale: :ja, league_id: @league, team_id: @team)
+    assert_equal "withdrawn", @participant.reload.status
+    assert_equal "approved", request.reload.status
+  end
+
+  test "owner can approve an update_md_id request and it updates member_ids" do
+    login_as!(@organizer_account, password: @password, member: @owner)
+    request = @team.roster_change_requests.create!(
+      kind: "update_md_id",
+      submitter_display_name: "Captain",
+      target_participant: @participant,
+      proposed_member_ids: ["MD-999"]
+    )
+
+    post approve_league_team_roster_change_request_path(locale: :ja, league_id: @league, team_id: @team, id: request)
+
+    assert_redirected_to league_team_roster_change_requests_path(locale: :ja, league_id: @league, team_id: @team)
+    assert_equal ["MD-999"], @participant.reload.member_ids
+    assert_equal "approved", request.reload.status
+  end
+
+  test "approve rolls back when applying the change fails validation" do
+    login_as!(@organizer_account, password: @password, member: @owner)
+    duplicate_request = @team.roster_change_requests.create!(
+      kind: "update_md_id",
+      submitter_display_name: "Captain",
+      target_participant: @participant,
+      proposed_member_ids: ["MD-DUP"]
+    )
+    @team.participants.create!(league: @league, display_name: "Other Player", member_ids: ["MD-DUP"])
+
+    post approve_league_team_roster_change_request_path(locale: :ja, league_id: @league, team_id: @team, id: duplicate_request)
+
+    assert_redirected_to league_team_roster_change_request_path(locale: :ja, league_id: @league, team_id: @team, id: duplicate_request)
+    follow_redirect!
+    assert_response :success
+    assert_equal "pending", duplicate_request.reload.status
+    assert_equal ["MD-1"], @participant.reload.member_ids
+  end
+
+  test "owner can reject a request" do
+    login_as!(@organizer_account, password: @password, member: @owner)
+    request = @team.roster_change_requests.create!(
+      kind: "add",
+      submitter_display_name: "Captain",
+      proposed_display_name: "Rejected Player"
+    )
+
+    assert_no_difference("Participant.count") do
+      post reject_league_team_roster_change_request_path(locale: :ja, league_id: @league, team_id: @team, id: request),
+        params: { organizer_note: "not eligible" }
+    end
+
+    assert_redirected_to league_team_roster_change_requests_path(locale: :ja, league_id: @league, team_id: @team)
+    request.reload
+    assert_equal "rejected", request.status
+    assert_equal @owner, request.reviewed_by
+    assert_equal "not eligible", request.organizer_note
+  end
+
+  test "cannot re-review an already reviewed request" do
+    login_as!(@organizer_account, password: @password, member: @owner)
+    request = @team.roster_change_requests.create!(
+      kind: "add",
+      submitter_display_name: "Captain",
+      proposed_display_name: "Already Reviewed"
+    )
+    request.update!(status: "approved", reviewed_by: @owner, reviewed_at: Time.current)
+
+    assert_no_difference("Participant.count") do
+      post approve_league_team_roster_change_request_path(locale: :ja, league_id: @league, team_id: @team, id: request)
+    end
+
+    assert_redirected_to league_team_roster_change_request_path(locale: :ja, league_id: @league, team_id: @team, id: request)
+    assert_equal "approved", request.reload.status
+  end
+
+  test "staff cannot access roster change requests" do
+    login_as!(@organizer_account, password: @password, member: @staff)
+    request = @team.roster_change_requests.create!(
+      kind: "add",
+      submitter_display_name: "Captain",
+      proposed_display_name: "Blocked Player"
+    )
+
+    get league_team_roster_change_requests_path(locale: :ja, league_id: @league, team_id: @team), headers: {
+      "HTTP_REFERER" => dashboard_path(locale: :ja)
+    }
+
+    assert_redirected_to dashboard_path(locale: :ja)
+
+    post approve_league_team_roster_change_request_path(locale: :ja, league_id: @league, team_id: @team, id: request), headers: {
+      "HTTP_REFERER" => dashboard_path(locale: :ja)
+    }
+    assert_redirected_to dashboard_path(locale: :ja)
+    assert_equal "pending", request.reload.status
+  end
+
+  test "index and show render for organizer" do
+    login_as!(@organizer_account, password: @password, member: @owner)
+    request = @team.roster_change_requests.create!(
+      kind: "remove",
+      submitter_display_name: "Captain",
+      target_participant: @participant
+    )
+
+    get league_team_roster_change_requests_path(locale: :ja, league_id: @league, team_id: @team)
+    assert_response :success
+
+    get league_team_roster_change_request_path(locale: :ja, league_id: @league, team_id: @team, id: request)
+    assert_response :success
+  end
+end

--- a/apps/ledger/test/integration/team_roster_change_portal_test.rb
+++ b/apps/ledger/test/integration/team_roster_change_portal_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+class TeamRosterChangePortalTest < ActionDispatch::IntegrationTest
+  test "returns 404 for unknown roster change token" do
+    get "/ja/roster/does-not-exist"
+    assert_response :not_found
+  end
+
+  test "shows portal page without authentication when token is valid" do
+    team = build_team_with_members!
+    team.regenerate_roster_change_token!
+
+    get "/ja/roster/#{team.roster_change_token}"
+
+    assert_response :success
+    assert_select "h1", text: /#{team.display_name}/
+    assert_match team.participants.first.display_name, response.body
+  end
+
+  test "creates an add request when posting valid form" do
+    team = build_team_with_members!
+    team.regenerate_roster_change_token!
+
+    assert_difference -> { team.roster_change_requests.count }, 1 do
+      post "/ja/roster/#{team.roster_change_token}/requests",
+        params: {
+          roster_change_request: {
+            kind: "add",
+            submitter_display_name: "Captain",
+            proposed_display_name: "New Recruit",
+            proposed_member_ids: ["MD-100", "", ""]
+          }
+        }
+    end
+
+    assert_redirected_to "/ja/roster/#{team.roster_change_token}"
+    request = team.roster_change_requests.order(:created_at).last
+    assert_equal "add", request.kind
+    assert_equal "pending", request.status
+    assert_equal "New Recruit", request.proposed_display_name
+    assert_equal ["MD-100"], request.proposed_member_ids
+  end
+
+  test "renders validation errors with 422 when the request is invalid" do
+    team = build_team_with_members!
+    team.regenerate_roster_change_token!
+
+    assert_no_difference -> { team.roster_change_requests.count } do
+      post "/ja/roster/#{team.roster_change_token}/requests",
+        params: {
+          roster_change_request: {
+            kind: "add",
+            submitter_display_name: "Captain",
+            proposed_display_name: ""
+          }
+        }
+    end
+
+    assert_response :unprocessable_entity
+    assert_includes response.body, team.display_name
+  end
+
+  test "shows request history with status" do
+    team = build_team_with_members!
+    team.regenerate_roster_change_token!
+    team.roster_change_requests.create!(
+      kind: "add",
+      submitter_display_name: "Captain",
+      proposed_display_name: "Historic Player"
+    )
+
+    get "/ja/roster/#{team.roster_change_token}"
+
+    assert_response :success
+    assert_includes response.body, "Historic Player"
+    assert_includes response.body, "Captain"
+  end
+
+  private
+
+  def build_team_with_members!
+    organizer = OrganizerAccount.create!(
+      display_name: "Roster Portal Org",
+      login_id: "roster-portal-#{SecureRandom.hex(4)}",
+      email: "roster-portal-#{SecureRandom.hex(4)}@example.com",
+      password: "password"
+    )
+    league = organizer.leagues.create!(
+      name: "Roster Portal League #{SecureRandom.hex(4)}",
+      status: "active",
+      roster_min_members: 4,
+      roster_max_members: 8,
+      lineup_size: 3,
+      substitute_size: 1
+    )
+    team = league.teams.create!(display_name: "Roster Portal Team")
+    team.participants.create!(league: league, display_name: "Existing Player", member_ids: ["MD-1"])
+    team
+  end
+end

--- a/apps/ledger/test/models/roster_change_request_test.rb
+++ b/apps/ledger/test/models/roster_change_request_test.rb
@@ -1,0 +1,112 @@
+require "test_helper"
+
+class RosterChangeRequestTest < ActiveSupport::TestCase
+  setup do
+    organizer_account = OrganizerAccount.create!(
+      email: "roster-change-request-test@example.com",
+      login_id: "roster-change-request-test",
+      password: "password",
+      display_name: "Roster Change Request Test"
+    )
+    @league = organizer_account.leagues.create!(
+      name: "Roster Change Request Test League",
+      started_at: Date.new(2026, 3, 23)
+    )
+    @team = @league.teams.create!(display_name: "Test Team")
+    @other_team = @league.teams.create!(display_name: "Other Team")
+    @participant = @team.participants.create!(league: @league, display_name: "Existing Player")
+    @other_team_participant = @other_team.participants.create!(league: @league, display_name: "Other Team Player")
+  end
+
+  test "requires submitter_display_name for every kind" do
+    request = @team.roster_change_requests.new(kind: "add", proposed_display_name: "New Player")
+    assert_not request.save
+    assert request.errors.of_kind?(:submitter_display_name, :blank)
+  end
+
+  test "add requires proposed_display_name" do
+    request = build_request(kind: "add", submitter_display_name: "Captain")
+    assert_not request.save
+    assert request.errors.of_kind?(:proposed_display_name, :blank)
+  end
+
+  test "add succeeds with proposed_display_name" do
+    request = build_request(kind: "add", submitter_display_name: "Captain", proposed_display_name: "New Player")
+    assert request.save
+  end
+
+  test "remove requires target_participant_id" do
+    request = build_request(kind: "remove", submitter_display_name: "Captain")
+    assert_not request.save
+    assert request.errors.of_kind?(:target_participant_id, :blank)
+  end
+
+  test "remove succeeds with a target_participant from the same team" do
+    request = build_request(kind: "remove", submitter_display_name: "Captain", target_participant: @participant)
+    assert request.save
+  end
+
+  test "update_md_id requires target_participant_id" do
+    request = build_request(kind: "update_md_id", submitter_display_name: "Captain", proposed_member_ids: ["MD-1"])
+    assert_not request.save
+    assert request.errors.of_kind?(:target_participant_id, :blank)
+  end
+
+  test "update_md_id requires proposed_member_ids" do
+    request = build_request(kind: "update_md_id", submitter_display_name: "Captain", target_participant: @participant)
+    assert_not request.save
+    assert request.errors.of_kind?(:proposed_member_ids, :blank)
+  end
+
+  test "update_md_id succeeds with target_participant and proposed_member_ids" do
+    request = build_request(
+      kind: "update_md_id",
+      submitter_display_name: "Captain",
+      target_participant: @participant,
+      proposed_member_ids: ["MD-1", "MD-2"]
+    )
+    assert request.save
+  end
+
+  test "rejects target_participant that belongs to another team" do
+    request = build_request(kind: "remove", submitter_display_name: "Captain", target_participant: @other_team_participant)
+    assert_not request.save
+    assert request.errors.of_kind?(:target_participant_id, :not_in_team)
+  end
+
+  test "rejects proposed_member_ids beyond the max limit" do
+    request = build_request(
+      kind: "update_md_id",
+      submitter_display_name: "Captain",
+      target_participant: @participant,
+      proposed_member_ids: %w[MD-1 MD-2 MD-3 MD-4]
+    )
+    assert_not request.save
+    assert request.errors.of_kind?(:proposed_member_ids, :too_many)
+  end
+
+  test "recent_first orders by created_at descending" do
+    older = build_request(kind: "add", submitter_display_name: "Captain", proposed_display_name: "Older")
+    older.save!
+    older.update_column(:created_at, 1.day.ago)
+    newer = build_request(kind: "add", submitter_display_name: "Captain", proposed_display_name: "Newer")
+    newer.save!
+
+    assert_equal [newer, older], @team.roster_change_requests.recent_first.to_a
+  end
+
+  test "reviewed? reflects non-pending status" do
+    request = build_request(kind: "add", submitter_display_name: "Captain", proposed_display_name: "New Player")
+    request.save!
+    assert_not request.reviewed?
+
+    request.update!(status: "approved")
+    assert request.reviewed?
+  end
+
+  private
+
+  def build_request(**attributes)
+    @team.roster_change_requests.new(attributes)
+  end
+end


### PR DESCRIPTION
## 概要
KAT-27 の完成形 (staging 起点 cherry-pick 版、#101 の差し替え)。tree は旧 feat branch と完全一致。

- 基盤: DB migration (roster_change_token / roster_change_requests) + model + token 管理 controller
- 公開 portal: `/roster/:token` で現ロスター表示 + 申請フォーム (add / remove / update_md_id) + 申請履歴
- organizer 審査: 一覧/詳細、approve (transaction で実ロスター適用、失敗時 rollback)、reject、再審査ガード
- teams#show に token 管理 section + pending 件数付きリンク、i18n ja/en 一式

## テスト
model + integration 3 本 (approve の実ロスター変異まで検証)。CI で実行