### PR TITLE
fix: 結果入力ページの 500 を修正 (time/date locale formats 未定義)

### DIFF
--- a/apps/ledger/config/locales/en.yml
+++ b/apps/ledger/config/locales/en.yml
@@ -1,4 +1,16 @@
 en:
+  date:
+    formats:
+      default: "%Y-%m-%d"
+      short: "%m/%d"
+      long: "%Y-%m-%d"
+  time:
+    formats:
+      default: "%Y-%m-%d %H:%M:%S"
+      short: "%m/%d %H:%M"
+      long: "%Y-%m-%d %H:%M"
+    am: am
+    pm: pm
   app:
     name: Katorin2
     application_name: Ledger

--- a/apps/ledger/config/locales/ja.yml
+++ b/apps/ledger/config/locales/ja.yml
@@ -1,4 +1,16 @@
 ja:
+  date:
+    formats:
+      default: "%Y/%m/%d"
+      short: "%m/%d"
+      long: "%Y年%m月%d日"
+  time:
+    formats:
+      default: "%Y/%m/%d %H:%M:%S"
+      short: "%m/%d %H:%M"
+      long: "%Y年%m月%d日 %H:%M"
+    am: 午前
+    pm: 午後
   app:
     name: Katorin2
     application_name: 台帳

--- a/apps/ledger/test/i18n/time_date_formats_test.rb
+++ b/apps/ledger/test/i18n/time_date_formats_test.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# 本番 500 の再発防止 (KAT hotfix):
+# ビューで l(time, format: :short/:long) を使うため、time/date formats が
+# 全 available_locale に定義されている必要がある。localize は format 欠落時に
+# raise_on_missing_translations に関係なく I18n::MissingTranslationData を raise する。
+class TimeDateFormatsTest < ActiveSupport::TestCase
+  SAMPLE_TIME = Time.utc(2026, 7, 4, 13, 59, 30).in_time_zone("Asia/Tokyo")
+  SAMPLE_DATE = Date.new(2026, 7, 4)
+
+  # 実コードで実際に使っている format のみを必須とする
+  USED_TIME_FORMATS = %i[short long].freeze
+
+  I18n.available_locales.each do |locale|
+    USED_TIME_FORMATS.each do |format|
+      test "#{locale} time.formats.#{format} は raise せず解決する" do
+        result = I18n.l(SAMPLE_TIME, format: format, locale: locale)
+        assert_kind_of String, result
+        refute_match(/translation missing/i, result, "#{locale} time.formats.#{format} が未定義")
+      end
+    end
+
+    test "#{locale} の date/time default format も解決する" do
+      assert_nothing_raised do
+        I18n.l(SAMPLE_TIME, format: :default, locale: locale)
+        I18n.l(SAMPLE_DATE, format: :default, locale: locale)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

本番 (katorin2.codenica.dev) の対戦結果入力ページで 500 が多発していたため緊急修正。

## 原因

保存済み結果のある試合の `MatchResultEntries#edit` で、`edit.html.erb:63` の
`l(@match_result.updated_at.in_time_zone("Asia/Tokyo"), format: :short)` が
**`ja.time.formats.short` 未定義**により `I18n::MissingTranslationData` を raise。

- `localize`/`l` は `raise_on_missing_translations` 設定に関係なく、format 欠落時に必ず raise する
- `rails-i18n` gem は未導入で、`ja.yml`/`en.yml` に `date`/`time` の formats が一切定義されていなかった
- 同根で `teams/show`・`roster_change_requests/show` の `format: :long` も潜在 500 だった

## 本番ログ (抜粋)

```
ActionView::Template::Error (Translation missing: ja.time.formats.short)
Caused by: I18n::MissingTranslationData (Translation missing: ja.time.formats.short)
app/views/match_result_entries/edit.html.erb:63
```

## 修正

- `ja.yml` / `en.yml` に `date.formats` / `time.formats` (default/short/long) を定義
- en は month_names 依存を避け数値フォーマットで自己完結
- 回帰テスト `test/i18n/time_date_formats_test.rb` を追加

## 検証

- i18n 層で `l(time, format: :short/:long)` が両ロケールで raise せず解決することを確認
- `test/i18n/time_date_formats_test.rb`: 6 runs, 0 failures
- `test/integration/regular_season_operations_flow_test.rb`: 24 runs, 701 assertions, 0 failures